### PR TITLE
#78 Add support for Bitbucket and Azure DevOps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Installing Python dependencies
+          command: pip install -r requirements_dev.txt
+      - run:
           name: Running tests
           command: tox -e py38-static_code_analysis -- -s -vv
   run-unit-and-functional-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,15 @@ version: 2.1
 orbs:
   aws-eks: circleci/aws-eks@1.0.3
 jobs:
-  run-unit-and-functional-tests-and-static-code-analysis:
+  run-static-code-analysis:
+    docker:
+      - image: circleci/python:3.8
+    steps:
+      - checkout
+      - run:
+          name: Running tests
+          command: tox -e py38-static_code_analysis -- -s -vv
+  run-unit-and-functional-tests:
     docker: 
       - image: circleci/python:3.8
     steps:
@@ -33,7 +41,7 @@ jobs:
           command: pip install -r requirements_dev.txt
       - run: 
           name: Running tests
-          command: tox -e py38-unit_and_functional_tests,py38-static_code_analysis -- -s -vv --junitxml=~/tox/junit.xml
+          command: tox -e py38-unit_and_functional_tests -- -s -vv --junitxml=~/tox/junit.xml
       - store_test_results:
           path: ~/tox/
       - run:
@@ -139,9 +147,15 @@ workflows:
   test-build-deploy:
     jobs:
       - ensure-package-version-number-incremented
-      - run-unit-and-functional-tests-and-static-code-analysis:
+      - run-static-code-analysis:
           requires:
             - ensure-package-version-number-incremented
+            filters:
+              branches:
+                ignore: master
+      - run-unit-and-functional-tests:
+          requires:
+            - run-static-code-analysis
           filters:
             branches:
               ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,9 +150,9 @@ workflows:
       - run-static-code-analysis:
           requires:
             - ensure-package-version-number-incremented
-            filters:
-              branches:
-                ignore: master
+          filters:
+            branches:
+              ignore: master
       - run-unit-and-functional-tests:
           requires:
             - run-static-code-analysis
@@ -161,7 +161,7 @@ workflows:
               ignore: master
       - build-dev-docker-image-push-to-dockerhub:
           requires:
-            - run-unit-and-functional-tests-and-static-code-analysis
+            - run-unit-and-functional-tests
           filters:
             branches:
               ignore: master

--- a/src/bodywork/constants.py
+++ b/src/bodywork/constants.py
@@ -16,8 +16,8 @@
 
 """
 This module contains constant values (e.g. default values) to be shared
-accoss all modules and tests as required. Constants should not be
-defined within seperate modules as this can lead to duplications and
+across all modules and tests as required. Constants should not be
+defined within separate modules as this can lead to duplications and
 inconsistencies.
 """
 import pkg_resources
@@ -49,3 +49,4 @@ GITLAB_SSH_FINGERPRINT = (
     "2048 SHA256:ROQFvPThGrW4RuWLoL9tq9I9zJ42fK4XywyRtbOz/EQ gitlab.com (RSA)"  # noqa
 )
 BITBUCKET_SSH_FINGERPRINT = "2048 SHA256:zzXQOXSRBEiUtuE8AikJYKwbHaxvSc0ojez9YXaGp1A bitbucket.org (RSA)"  # noqa
+AZURE_SSH_FINGERPRINT = "2048 SHA256:ohD8VZEXGWo6Ez8GSEJQ9WpafgLFsOfLOtGGQCQo6Og ssh.dev.azure.com (RSA)"  # noqa

--- a/src/bodywork/git.py
+++ b/src/bodywork/git.py
@@ -33,6 +33,7 @@ from .constants import (
     GITLAB_SSH_FINGERPRINT,
     BITBUCKET_SSH_FINGERPRINT,
     GIT_SSH_COMMAND,
+    AZURE_SSH_FINGERPRINT,
 )
 from .logs import bodywork_log_factory
 
@@ -184,6 +185,7 @@ def get_ssh_public_key_from_domain(hostname: str) -> str:
         "github.com": GITHUB_SSH_FINGERPRINT,
         "gitlab.com": GITLAB_SSH_FINGERPRINT,
         "bitbucket.org": BITBUCKET_SSH_FINGERPRINT,
+        "ssh.dev.azure.com": AZURE_SSH_FINGERPRINT,
     }
     if hostname in fingerprints:
         try:

--- a/src/bodywork/git.py
+++ b/src/bodywork/git.py
@@ -158,7 +158,8 @@ def setup_ssh_for_git_host(hostname: str) -> None:
         ) from e
 
     os.environ[GIT_SSH_COMMAND] = (
-        f"ssh -i '{private_key}'" f" -o UserKnownHostsFile='{known_hosts}'"
+        f"ssh -i '{private_key}' -o UserKnownHostsFile='{known_hosts}'"
+        f" -o IdentitiesOnly=yes"
     )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,7 +53,7 @@ def bitbucket_repo_connection_string() -> str:
 
 @fixture(scope="function")
 def azure_repo_connection_string() -> str:
-    return "git@ssh.dev.azure.com:v3/Bodyworkml/test-repos/test-repos"
+    return "git@ssh.dev.azure.com:v3/Bodyworkml/test-repos/private-test-repos"
 
 
 @fixture(scope="function")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -47,6 +47,16 @@ def github_repo_connection_string() -> str:
 
 
 @fixture(scope="function")
+def bitbucket_repo_connection_string() -> str:
+    return "git@bitbucket.org:bodywork/private-test-repo.git"
+
+
+@fixture(scope="function")
+def azure_repo_connection_string() -> str:
+    return "git@ssh.dev.azure.com:v3/Bodyworkml/test-repos/test-repos"
+
+
+@fixture(scope="function")
 def random_test_namespace() -> str:
     rand_test_namespace = f"bodywork-integration-tests-{randint(0, 10000)}"
     print(
@@ -84,7 +94,7 @@ def set_github_ssh_private_key_env_var() -> None:
 
 
 @fixture(scope="function")
-def set_gitlab_ssh_private_key_env_var() -> None:
+def set_git_ssh_private_key_env_var() -> None:
     if "CIRCLECI" in os.environ:
         private_key = Path.home() / ".ssh/id_rsa_e28827a593edd69f1a58cf07a7755107"
     else:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -102,7 +102,7 @@ def set_git_ssh_private_key_env_var() -> None:
     if private_key.exists():
         os.environ[SSH_PRIVATE_KEY_ENV_VAR] = private_key.read_text()
     else:
-        raise RuntimeError("cannot locate private SSH key to use for GitLab")
+        raise RuntimeError("cannot locate private SSH key to use")
 
 
 @fixture(scope="function")

--- a/tests/integration/test_git_integration.py
+++ b/tests/integration/test_git_integration.py
@@ -45,10 +45,36 @@ def test_that_git_project_repo_can_be_cloned_from_gitlab_using_ssh(
         setup_bodywork_test_project: Iterable[bool],
         gitlab_repo_connection_string: str,
         cloned_project_repo_location: Path,
-        set_gitlab_ssh_private_key_env_var: None,
+        set_git_ssh_private_key_env_var: None,
 ):
     try:
         download_project_code_from_repo(gitlab_repo_connection_string)
+        assert cloned_project_repo_location.exists()
+    except Exception:
+        assert False
+
+
+def test_that_git_project_repo_can_be_cloned_from_bitbucket_using_ssh(
+        setup_bodywork_test_project: Iterable[bool],
+        bitbucket_repo_connection_string: str,
+        cloned_project_repo_location: Path,
+        set_git_ssh_private_key_env_var: None,
+):
+    try:
+        download_project_code_from_repo(bitbucket_repo_connection_string)
+        assert cloned_project_repo_location.exists()
+    except Exception:
+        assert False
+
+
+def test_that_git_project_repo_can_be_cloned_from_azure_using_ssh(
+        setup_bodywork_test_project: Iterable[bool],
+        azure_repo_connection_string: str,
+        cloned_project_repo_location: Path,
+        set_git_ssh_private_key_env_var: None,
+):
+    try:
+        download_project_code_from_repo(azure_repo_connection_string)
         assert cloned_project_repo_location.exists()
     except Exception:
         assert False


### PR DESCRIPTION
This PR closes #78. Support for Bitbucket and Azure Dev Ops has been added by adding the SSH key fingerprints for these hosts and testing against private test repo's in the respective sites.

The same SSH key to access Gitlab is used to access these hosted private repo's for testing.

Also included in this PR is an update to the CircleCI config for the static code analysis to be performed as a separate step before running unit tests.