### PR TITLE
123 update secret command

### DIFF
--- a/requirements_pkg.txt
+++ b/requirements_pkg.txt
@@ -2,3 +2,4 @@ Cerberus==1.3.2
 kubernetes==17.17.0
 PyYAML==5.4.1
 requests>=2.25.0
+pydantic>=1.8.2

--- a/requirements_pkg.txt
+++ b/requirements_pkg.txt
@@ -2,4 +2,3 @@ Cerberus==1.3.2
 kubernetes==17.17.0
 PyYAML==5.4.1
 requests>=2.25.0
-pydantic>=1.8.2

--- a/src/bodywork/cli/cli.py
+++ b/src/bodywork/cli/cli.py
@@ -491,10 +491,14 @@ def secret(args: Namespace) -> None:
     group = args.group
     name = args.name
     key_value_strings = args.data
-    if (command == "create" or command == "delete" or command == "update") and name == "":
+    if (
+        command == "create" or command == "delete" or command == "update"
+    ) and name == "":
         print("please specify the name of the secret")
         sys.exit(1)
-    if (command == "create" or command == "delete" or command == "update") and group == "":
+    if (
+        command == "create" or command == "delete" or command == "update"
+    ) and group == "":
         print("please specify the secret group the secret belongs to")
         sys.exit(1)
     elif (command == "create" or command == "update") and key_value_strings == []:
@@ -515,7 +519,9 @@ def secret(args: Namespace) -> None:
                 BODYWORK_DEPLOYMENT_JOBS_NAMESPACE, group, name, var_names_and_values
             )
         else:
-            update_secret(BODYWORK_DEPLOYMENT_JOBS_NAMESPACE, group, name, var_names_and_values)
+            update_secret(
+                BODYWORK_DEPLOYMENT_JOBS_NAMESPACE, group, name, var_names_and_values
+            )
     elif command == "delete":
         load_kubernetes_config()
         delete_secret(BODYWORK_DEPLOYMENT_JOBS_NAMESPACE, group, name)

--- a/src/bodywork/cli/cli.py
+++ b/src/bodywork/cli/cli.py
@@ -49,6 +49,7 @@ from .secrets import (
     delete_secret,
     display_secrets,
     parse_cli_secrets_strings,
+    update_secret,
 )
 from .setup_namespace import (
     is_namespace_available_for_bodywork,
@@ -199,7 +200,7 @@ def cli() -> None:
     secret_cmd_parser.add_argument(
         "command",
         type=str,
-        choices=["create", "delete", "display"],
+        choices=["create", "delete", "update", "display"],
         help="Secrets action to perform.",
     )
     secret_cmd_parser.add_argument(
@@ -490,16 +491,16 @@ def secret(args: Namespace) -> None:
     group = args.group
     name = args.name
     key_value_strings = args.data
-    if (command == "create" or command == "delete") and name == "":
-        print("please specify a name for the secret you want to create")
+    if (command == "create" or command == "delete" or command == "update") and name == "":
+        print("please specify the name of the secret")
         sys.exit(1)
-    if (command == "create" or command == "delete") and group == "":
+    if (command == "create" or command == "delete" or command == "update") and group == "":
         print("please specify the secret group the secret belongs to")
         sys.exit(1)
-    elif command == "create" and key_value_strings == []:
-        print("please specify keys and values for the secret you want to create")
+    elif (command == "create" or command == "update") and key_value_strings == []:
+        print("please specify keys and values for the secret you want to create/update")
         sys.exit(1)
-    elif command == "create":
+    elif command == "create" or command == "update":
         try:
             var_names_and_values = parse_cli_secrets_strings(key_value_strings)
         except ValueError:
@@ -509,9 +510,12 @@ def secret(args: Namespace) -> None:
             )
             sys.exit(1)
         load_kubernetes_config()
-        create_secret(
-            BODYWORK_DEPLOYMENT_JOBS_NAMESPACE, group, name, var_names_and_values
-        )
+        if command == "create":
+            create_secret(
+                BODYWORK_DEPLOYMENT_JOBS_NAMESPACE, group, name, var_names_and_values
+            )
+        else:
+            update_secret(BODYWORK_DEPLOYMENT_JOBS_NAMESPACE, group, name, var_names_and_values)
     elif command == "delete":
         load_kubernetes_config()
         delete_secret(BODYWORK_DEPLOYMENT_JOBS_NAMESPACE, group, name)

--- a/src/bodywork/cli/cli.py
+++ b/src/bodywork/cli/cli.py
@@ -207,11 +207,10 @@ def cli() -> None:
         "--group",
         required=False,
         type=str,
-        default="",
         help="The secrets group this secret belongs in.",
     )
     secret_cmd_parser.add_argument(
-        "--name", type=str, default="", help="The name given to the Kubernetes secret."
+        "--name", type=str, help="The name given to the Kubernetes secret."
     )
     secret_cmd_parser.add_argument(
         "--data",
@@ -493,12 +492,12 @@ def secret(args: Namespace) -> None:
     key_value_strings = args.data
     if (
         command == "create" or command == "delete" or command == "update"
-    ) and name == "":
+    ) and not name:
         print("please specify the name of the secret")
         sys.exit(1)
     if (
         command == "create" or command == "delete" or command == "update"
-    ) and group == "":
+    ) and not group:
         print("please specify the secret group the secret belongs to")
         sys.exit(1)
     elif (command == "create" or command == "update") and key_value_strings == []:
@@ -533,7 +532,7 @@ def secret(args: Namespace) -> None:
         display_secrets(
             BODYWORK_DEPLOYMENT_JOBS_NAMESPACE,
             group,
-            secret=name if name != "" else None,
+            name,
         )
     sys.exit(0)
 

--- a/src/bodywork/cli/secrets.py
+++ b/src/bodywork/cli/secrets.py
@@ -79,6 +79,30 @@ def create_secret(
     print(f"secret={secret_name} created in group={group}")
 
 
+def update_secret(
+    namespace: str, group: str, secret_name: str, keys_and_values: Dict[str, str]
+) -> None:
+    """Update a secret within a k8s namespace.
+
+    :param namespace: Namespace in which to look for secrets.
+    :param group: The group the secret belongs to.
+    :param secret_name: The name of the secret to update.
+    :param keys_and_values:
+    """
+    if not k8s.namespace_exists(namespace):
+        print(f"namespace={namespace} could not be found on k8s cluster")
+        return None
+    if not k8s.secret_exists(
+        namespace, _create_complete_secret_name(group, secret_name)
+    ):
+        print(f"secret={secret_name} could not be found in group={group}")
+        return None
+    k8s.update_secret(
+        namespace, _create_complete_secret_name(group, secret_name), keys_and_values
+    )
+    print(f"secret={secret_name} in group={group} updated")
+
+
 def delete_secret(namespace: str, group: str, secret_name: str) -> None:
     """Delete a secret within a k8s namespace.
 

--- a/src/bodywork/cli/secrets.py
+++ b/src/bodywork/cli/secrets.py
@@ -150,9 +150,9 @@ def display_secrets(
             except KeyError:
                 print(f"cannot find secret={secret_name} in namespace={namespace}")
         else:
-            for key, value in secrets.items():
+            for key, secret in secrets.items():
                 print(f"\n-- {key}:")
-                for secret_key, secret_value in value.data.items():
+                for secret_key, secret_value in secret.data.items():
                     print(f"-> {secret_key}={secret_value}".replace("\n", ""))
 
 

--- a/src/bodywork/cli/secrets.py
+++ b/src/bodywork/cli/secrets.py
@@ -135,12 +135,12 @@ def display_secrets(
     if not k8s.namespace_exists(namespace):
         print(f"namespace={namespace} could not be found on k8s cluster")
         return None
-    if secret_name and group is None:
+    if secret_name and not group:
         print("please specify which secrets group the secret belongs to.")
         return None
     else:
         secrets = k8s.list_secrets(namespace, group)
-        if secret_name is not None:
+        if secret_name:
             try:
                 print(f"\n-- {secret_name}:")
                 for key, value in secrets[

--- a/src/bodywork/cli/secrets.py
+++ b/src/bodywork/cli/secrets.py
@@ -123,36 +123,36 @@ def delete_secret(namespace: str, group: str, secret_name: str) -> None:
 
 
 def display_secrets(
-    namespace: str, group: Optional[str] = None, secret: Optional[str] = None
+    namespace: str, group: Optional[str] = None, secret_name: Optional[str] = None
 ) -> None:
     """Print secrets to stdout.
 
     :param namespace: Namespace in which to look for secrets.
     :param group: Group the secrets to display belong to.
-    :param secret: Display the available keys in just the secret with
+    :param secret_name: Display the available keys in just the secret with
         this name, defaults to None
     """
     if not k8s.namespace_exists(namespace):
         print(f"namespace={namespace} could not be found on k8s cluster")
         return None
-    if secret and group is None:
+    if secret_name and group is None:
         print("please specify which secrets group the secret belongs to.")
         return None
     else:
         secrets = k8s.list_secrets(namespace, group)
-        if secret is not None:
+        if secret_name is not None:
             try:
-                print(f"\n-- {secret}:")
-                for secret_key, secret_value in secrets[
-                    _create_complete_secret_name(cast(str, group), secret)
-                ].items():
-                    print(f"-> {secret_key}={secret_value}".replace("\n", ""))
-            except KeyError:
-                print(f"cannot find secret={secret} in namespace={namespace}")
-        else:
-            for secret_name, secret_data in secrets.items():
                 print(f"\n-- {secret_name}:")
-                for secret_key, secret_value in secret_data.items():
+                for key, value in secrets[
+                    _create_complete_secret_name(cast(str, group), secret_name)
+                ].data.items():
+                    print(f"-> {key}={value}".replace("\n", ""))
+            except KeyError:
+                print(f"cannot find secret={secret_name} in namespace={namespace}")
+        else:
+            for key, value in secrets.items():
+                print(f"\n-- {key}:")
+                for secret_key, secret_value in value.data.items():
                     print(f"-> {secret_key}={secret_value}".replace("\n", ""))
 
 

--- a/src/bodywork/k8s/__init__.py
+++ b/src/bodywork/k8s/__init__.py
@@ -55,6 +55,7 @@ from .secrets import (
     delete_secret,
     list_secrets,
     replicate_secrets_in_namespace,
+    update_secret,
 )
 from .service_deployments import (
     DeploymentStatus,
@@ -132,4 +133,5 @@ __all__ = [
     "create_k8s_environment_variables",
     "EnvVars",
     "replicate_secrets_in_namespace",
+    "update_secret",
 ]

--- a/src/bodywork/k8s/__init__.py
+++ b/src/bodywork/k8s/__init__.py
@@ -138,3 +138,4 @@ __all__ = [
     "update_secret",
     "Secret",
     "update_workflow_cronjob",
+]

--- a/src/bodywork/k8s/__init__.py
+++ b/src/bodywork/k8s/__init__.py
@@ -56,6 +56,7 @@ from .secrets import (
     list_secrets,
     replicate_secrets_in_namespace,
     update_secret,
+    Secret,
 )
 from .service_deployments import (
     DeploymentStatus,
@@ -134,4 +135,5 @@ __all__ = [
     "EnvVars",
     "replicate_secrets_in_namespace",
     "update_secret",
+    "Secret",
 ]

--- a/src/bodywork/k8s/secrets.py
+++ b/src/bodywork/k8s/secrets.py
@@ -30,10 +30,9 @@ from ..constants import SECRET_GROUP_LABEL, BODYWORK_DEPLOYMENT_JOBS_NAMESPACE
 
 @dataclass
 class Secret:
-    def __init__(self, name: str, group: str, data: Dict[str, str]):
-        self.name = name
-        self.group = group
-        self.data = data
+    name: str
+    group: str
+    data: Dict[str, str]
 
 
 def configure_env_vars_from_secrets(
@@ -189,7 +188,7 @@ def delete_secret(namespace: str, name: str) -> None:
     k8s.CoreV1Api().delete_namespaced_secret(namespace=namespace, name=name)
 
 
-def list_secrets(namespace: str, group: str = None) -> Dict[str, Secret]:
+def list_secrets(namespace: str, group: Optional[str] = None) -> Dict[str, Secret]:
     """Get all secrets and their (decoded) data.
 
     :param namespace: Namespace in which to list secrets.

--- a/src/bodywork/k8s/secrets.py
+++ b/src/bodywork/k8s/secrets.py
@@ -204,7 +204,9 @@ def list_secrets(namespace: str, group: str = None) -> Dict[str, Secret]:
     secrets = {
         s.metadata.name: Secret(
             s.metadata.name,
-            s.metadata.labels[SECRET_GROUP_LABEL] if s.metadata.labels and SECRET_GROUP_LABEL in s.metadata.labels else None,
+            s.metadata.labels[SECRET_GROUP_LABEL]
+            if s.metadata.labels and SECRET_GROUP_LABEL in s.metadata.labels
+            else None,
             s.string_data if s.string_data else s.data,
         )
         for s in result.items

--- a/src/bodywork/k8s/secrets.py
+++ b/src/bodywork/k8s/secrets.py
@@ -20,7 +20,7 @@ manage secrets required by Bodywork stage containers.
 """
 from typing import Dict, List, Optional, Tuple
 from base64 import b64decode
-from pydantic.dataclasses import dataclass
+from dataclasses import dataclass
 
 from kubernetes import client as k8s
 

--- a/src/bodywork/k8s/secrets.py
+++ b/src/bodywork/k8s/secrets.py
@@ -20,6 +20,7 @@ manage secrets required by Bodywork stage containers.
 """
 from typing import Dict, List, Optional, Tuple
 from base64 import b64decode
+from pydantic.dataclasses import dataclass
 
 from kubernetes import client as k8s
 
@@ -27,6 +28,7 @@ from .utils import make_valid_k8s_name
 from ..constants import SECRET_GROUP_LABEL, BODYWORK_DEPLOYMENT_JOBS_NAMESPACE
 
 
+@dataclass
 class Secret:
     def __init__(self, name: str, group: str, data: Dict[str, str]):
         self.name = name

--- a/tests/integration/test_k8s_with_secrets.py
+++ b/tests/integration/test_k8s_with_secrets.py
@@ -55,6 +55,23 @@ def test_update_secret():
     assert "secret=bodywork-test-project-credentials in group=testsecrets updated" in process_one.stdout
 
 
+@mark.usefixtures("add_secrets")
+@mark.usefixtures("setup_cluster")
+def test_display_all_secrets():
+    process_one = run(
+        [
+            "bodywork",
+            "secret",
+            "display",
+        ],
+        encoding="utf-8",
+        capture_output=True,
+    )
+
+    assert process_one.returncode == 0
+    assert "testsecrets-bodywork-test-project-credentials" in process_one.stdout
+
+
 @mark.usefixtures("setup_cluster")
 def test_cli_secret_handler_crud(test_namespace: str):
 

--- a/tests/integration/test_k8s_with_secrets.py
+++ b/tests/integration/test_k8s_with_secrets.py
@@ -34,6 +34,27 @@ def test_replicate_secrets_in_namespace():
     assert secret_exists(namespace, "bodywork-test-project-credentials", "USERNAME")
 
 
+@mark.usefixtures("add_secrets")
+@mark.usefixtures("setup_cluster")
+def test_update_secret():
+    process_one = run(
+        [
+            "bodywork",
+            "secret",
+            "update",
+            "--group=testsecrets",
+            "--name=bodywork-test-project-credentials",
+            "--data",
+            "PASSWORD=updated",
+        ],
+        encoding="utf-8",
+        capture_output=True,
+    )
+
+    assert process_one.returncode == 0
+    assert "secret=bodywork-test-project-credentials in group=testsecrets updated" in process_one.stdout
+
+
 @mark.usefixtures("setup_cluster")
 def test_cli_secret_handler_crud(test_namespace: str):
 

--- a/tests/unit_and_functional/test_cli.py
+++ b/tests/unit_and_functional/test_cli.py
@@ -146,7 +146,7 @@ def test_cli_secret_handler_error_handling():
         encoding="utf-8",
         capture_output=True,
     )
-    assert "please specify a name for the secret" in process_one.stdout
+    assert "please specify the name of the secret" in process_one.stdout
 
     process_two = run(
         [
@@ -161,7 +161,7 @@ def test_cli_secret_handler_error_handling():
         encoding="utf-8",
         capture_output=True,
     )
-    assert "please specify a name for the secret" in process_two.stdout
+    assert "please specify the name of the secret" in process_two.stdout
 
     process_three = run(
         [

--- a/tests/unit_and_functional/test_cli_secrets.py
+++ b/tests/unit_and_functional/test_cli_secrets.py
@@ -125,8 +125,12 @@ def test_delete_secrets_in_namespace(
 @patch("bodywork.cli.secrets.k8s")
 def test_display_secrets(mock_k8s_module: MagicMock, capsys: CaptureFixture):
     mock_k8s_module.list_secrets.return_value = {
-            "PROD-test-credentials": Secret("PROD-test-credentials", "PROD", {"USERNAME": "alex", "PASSWORD": "alex123"}),
-            "DEV-more-test-credentials": Secret("DEV-more-test-credentials", "DEV", {"FOO": "bar"}),
+        "PROD-test-credentials": Secret(
+            "PROD-test-credentials", "PROD", {"USERNAME": "alex", "PASSWORD": "alex123"}
+        ),
+        "DEV-more-test-credentials": Secret(
+            "DEV-more-test-credentials", "DEV", {"FOO": "bar"}
+        ),
     }
 
     mock_k8s_module.namespace_exists.return_value = False

--- a/tests/unit_and_functional/test_cli_secrets.py
+++ b/tests/unit_and_functional/test_cli_secrets.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 from pytest import raises
 from _pytest.capture import CaptureFixture
 
+from bodywork.k8s.secrets import Secret
 from bodywork.cli.secrets import (
     create_secret,
     delete_secret,
@@ -124,23 +125,23 @@ def test_delete_secrets_in_namespace(
 @patch("bodywork.cli.secrets.k8s")
 def test_display_secrets(mock_k8s_module: MagicMock, capsys: CaptureFixture):
     mock_k8s_module.list_secrets.return_value = {
-        "PROD-test-credentials": {"USERNAME": "alex", "PASSWORD": "alex123"},
-        "DEV-more-test-credentials": {"FOO": "bar"},
+            "PROD-test-credentials": Secret("PROD-test-credentials", "PROD", {"USERNAME": "alex", "PASSWORD": "alex123"}),
+            "DEV-more-test-credentials": Secret("DEV-more-test-credentials", "DEV", {"FOO": "bar"}),
     }
 
     mock_k8s_module.namespace_exists.return_value = False
-    display_secrets("the-namespace", secret="test-credentials")
+    display_secrets("the-namespace", secret_name="test-credentials")
     captured_one = capsys.readouterr()
     assert "could not be found on k8s cluster" in captured_one.out
 
     mock_k8s_module.namespace_exists.return_value = True
-    display_secrets("the-namespace", secret="test-credentials", group="PROD")
+    display_secrets("the-namespace", secret_name="test-credentials", group="PROD")
     captured_two = capsys.readouterr()
     assert "USERNAME=alex" in captured_two.out
     assert "PASSWORD=alex123" in captured_two.out
 
     mock_k8s_module.namespace_exists.return_value = True
-    display_secrets("the-namespace", secret="test-credentialz", group="DEV")
+    display_secrets("the-namespace", secret_name="test-credentialz", group="DEV")
     captured_three = capsys.readouterr()
     assert "cannot find secret=test-credentialz" in captured_three.out
 

--- a/tests/unit_and_functional/test_k8s_secrets.py
+++ b/tests/unit_and_functional/test_k8s_secrets.py
@@ -146,7 +146,9 @@ def test_list_secrets_in_namespace_returns_decoded_secret_data(
             items=[
                 kubernetes.client.V1Secret(
                     metadata=kubernetes.client.V1ObjectMeta(
-                        namespace="bodywork-dev", name="xyz-pytest-secret", labels={f"{SECRET_GROUP_LABEL}": "xyz"}
+                        namespace="bodywork-dev",
+                        name="xyz-pytest-secret",
+                        labels={f"{SECRET_GROUP_LABEL}": "xyz"},
                     ),
                     string_data={"ALEX": b"aW9hbm5pZGVz"},
                 )

--- a/tests/unit_and_functional/test_k8s_secrets.py
+++ b/tests/unit_and_functional/test_k8s_secrets.py
@@ -29,6 +29,7 @@ from bodywork.k8s.secrets import (
     delete_secret,
     list_secrets,
     secret_exists,
+    update_secret,
 )
 from bodywork.constants import SECRET_GROUP_LABEL
 
@@ -101,6 +102,25 @@ def test_create_secret_tries_to_create_secret_with_k8s_api(
                 namespace="bodywork-dev",
                 name="pytest-secret",
                 labels={SECRET_GROUP_LABEL: "xyz"},
+            ),
+            string_data={"KEY": "value"},
+        ),
+    )
+
+
+@patch("kubernetes.client.CoreV1Api")
+def test_update_secret_updates_secret_with_k8s_api(
+    mock_k8s_core_api: MagicMock,
+):
+    update_secret("bodywork-dev", "test-pytest-secret", {"KEY": "value"})
+
+    mock_k8s_core_api().patch_namespaced_secret.assert_called_once_with(
+        "test-pytest-secret",
+        "bodywork-dev",
+        kubernetes.client.V1Secret(
+            metadata=kubernetes.client.V1ObjectMeta(
+                namespace="bodywork-dev",
+                name="test-pytest-secret",
             ),
             string_data={"KEY": "value"},
         ),

--- a/tests/unit_and_functional/test_k8s_secrets.py
+++ b/tests/unit_and_functional/test_k8s_secrets.py
@@ -150,7 +150,7 @@ def test_list_secrets_in_namespace_returns_decoded_secret_data(
                         name="xyz-pytest-secret",
                         labels={f"{SECRET_GROUP_LABEL}": "xyz"},
                     ),
-                    string_data={"ALEX": b"aW9hbm5pZGVz"},
+                    data={"ALEX": b"aW9hbm5pZGVz"},
                 )
             ]
         )

--- a/tests/unit_and_functional/test_k8s_secrets.py
+++ b/tests/unit_and_functional/test_k8s_secrets.py
@@ -146,7 +146,7 @@ def test_list_secrets_in_namespace_returns_decoded_secret_data(
             items=[
                 kubernetes.client.V1Secret(
                     metadata=kubernetes.client.V1ObjectMeta(
-                        namespace="bodywork-dev", name="pytest-secret", labels="xyz"
+                        namespace="bodywork-dev", name="xyz-pytest-secret", labels={f"{SECRET_GROUP_LABEL}": "xyz"}
                     ),
                     string_data={"ALEX": b"aW9hbm5pZGVz"},
                 )
@@ -157,5 +157,7 @@ def test_list_secrets_in_namespace_returns_decoded_secret_data(
     mock_k8s_core_api().list_namespaced_secret.assert_called_once_with(
         namespace="bodywork-dev", label_selector=f"{SECRET_GROUP_LABEL}=xyz"
     )
+
     assert len(secrets) == 1
-    assert secrets["pytest-secret"]["ALEX"] == "ioannides"
+    assert secrets["xyz-pytest-secret"].name == "xyz-pytest-secret"
+    assert secrets["xyz-pytest-secret"].data["ALEX"] == "ioannides"


### PR DESCRIPTION
This PR closes #123 . This PR adds the ability to update a secret via the cli. 

In addition to this the PR contains a refactor of the display all Secrets command (including a bug fix) so that a (Bodywork) Secrets object is returned. This allows us to return additional fields such as Group and leaves it extensible for the future.