### PR TITLE
122 update cronjob command

### DIFF
--- a/src/bodywork/cli/cli.py
+++ b/src/bodywork/cli/cli.py
@@ -102,17 +102,17 @@ def cli() -> None:
         help="Deployment action to perform.",
     )
     deployment_cmd_parser.add_argument(
-        "--name", type=str, default="", help="The name given to the workflow job."
+        "--name", type=str, help="The name given to the workflow job."
     )
     deployment_cmd_parser.add_argument(
         "--git-repo-url",
         type=str,
-        default="",
         help="Git repository URL containing the Bodywork project.",
     )
     deployment_cmd_parser.add_argument(
         "--git-repo-branch",
         type=str,
+        default="master",
         help="Git repository branch to run.",
     )
     deployment_cmd_parser.add_argument(
@@ -354,10 +354,10 @@ def deployment(args: Namespace) -> None:
     git_repo_branch = args.git_repo_branch
     run_workflow_controller_locally = args.local_workflow_controller
 
-    if command == "create" and git_repo_url == "":
+    if command == "create" and not git_repo_url:
         print("please specify Git repo URL for the deployment you want to create")
         sys.exit(1)
-    if command != "create" and name == "":
+    if command != "create" and not name:
         print("please specify --name for the deployment job")
         sys.exit(1)
     if command == "create":

--- a/src/bodywork/cli/cli.py
+++ b/src/bodywork/cli/cli.py
@@ -383,6 +383,7 @@ def deployment(args: Namespace) -> None:
                 BODYWORK_DEPLOYMENT_JOBS_NAMESPACE,
                 git_repo_url,
                 git_repo_branch,
+                name,
                 retries,
             )
     elif command == "logs":

--- a/src/bodywork/cli/cli.py
+++ b/src/bodywork/cli/cli.py
@@ -425,6 +425,11 @@ def cronjob(args: Namespace) -> None:
     elif command == "create" and not git_repo_url:
         print("please specify Git repo URL for the cronjob you want to create")
         sys.exit(1)
+    elif command == "update" and (git_repo_url and not git_repo_branch) or (
+            not git_repo_url and git_repo_branch
+    ):
+        print("Please specify both --git-repo-url and --git-repo-branch.")
+        sys.exit(1)
 
     load_kubernetes_config()
     if command == "create":
@@ -444,11 +449,6 @@ def cronjob(args: Namespace) -> None:
             history_limit,
         )
     elif command == "update":
-        if (git_repo_url and not git_repo_branch) or (
-            not git_repo_url and git_repo_branch
-        ):
-            print("Please specify both --git-repo-url and --git-repo-branch.")
-            sys.exit(1)
         update_workflow_cronjob_in_namespace(
             BODYWORK_DEPLOYMENT_JOBS_NAMESPACE,
             name,

--- a/src/bodywork/cli/cli.py
+++ b/src/bodywork/cli/cli.py
@@ -39,6 +39,7 @@ from .workflow_jobs import (
     display_workflow_job_logs,
     delete_workflow_cronjob_in_namespace,
     delete_workflow_job_in_namespace,
+    update_workflow_cronjob_in_namespace,
 )
 from .service_deployments import (
     delete_service_deployment_in_namespace,
@@ -112,7 +113,6 @@ def cli() -> None:
     deployment_cmd_parser.add_argument(
         "--git-repo-branch",
         type=str,
-        default="master",
         help="Git repository branch to run.",
     )
     deployment_cmd_parser.add_argument(
@@ -136,28 +136,25 @@ def cli() -> None:
     cronjob_cmd_parser.add_argument(
         "command",
         type=str,
-        choices=["create", "delete", "display", "history", "logs"],
+        choices=["create", "update", "delete", "display", "history", "logs"],
         help="Cronjob action to perform.",
     )
     cronjob_cmd_parser.add_argument(
-        "--name", type=str, default="", help="The name given to the cronjob."
+        "--name", type=str, help="The name given to the cronjob."
     )
     cronjob_cmd_parser.add_argument(
         "--schedule",
         type=str,
-        default="",
-        help='Workflow cronjob expressed as a cron schedule - e.g. "0,30 * * * *".',
+        help='Workflow cronjob expressed as a cron schedule - e.g. "0 30 * * *".',
     )
     cronjob_cmd_parser.add_argument(
         "--git-repo-url",
         type=str,
-        default="",
         help="Git repository URL containing the Bodywork project codebase.",
     )
     cronjob_cmd_parser.add_argument(
         "--git-repo-branch",
         type=str,
-        default="master",
         help="Git repository branch to run.",
     )
     cronjob_cmd_parser.add_argument(
@@ -418,17 +415,19 @@ def cronjob(args: Namespace) -> None:
         or command == "delete"
         or command == "history"
         or command == "logs"
-    ) and name == "":
+        or command == "update"
+    ) and not name:
         print("please specify --name for the cronjob")
         sys.exit(1)
-    elif command == "create" and schedule == "":
+    elif command == "create" and not schedule:
         print("please specify schedule for the cronjob you want to create")
         sys.exit(1)
-    elif command == "create" and git_repo_url == "":
+    elif command == "create" and not git_repo_url:
         print("please specify Git repo URL for the cronjob you want to create")
         sys.exit(1)
-    elif command == "create":
-        load_kubernetes_config()
+
+    load_kubernetes_config()
+    if command == "create":
         if not is_namespace_available_for_bodywork(BODYWORK_DEPLOYMENT_JOBS_NAMESPACE):
             print(
                 f"namespace={BODYWORK_DEPLOYMENT_JOBS_NAMESPACE} is not setup for"
@@ -440,21 +439,32 @@ def cronjob(args: Namespace) -> None:
             schedule,
             name,
             git_repo_url,
+            git_repo_branch if git_repo_branch else "master",
+            retries,
+            history_limit,
+        )
+    elif command == "update":
+        if (git_repo_url and not git_repo_branch) or (
+            not git_repo_url and git_repo_branch
+        ):
+            print("Please specify both --git-repo-url and --git-repo-branch.")
+            sys.exit(1)
+        update_workflow_cronjob_in_namespace(
+            BODYWORK_DEPLOYMENT_JOBS_NAMESPACE,
+            name,
+            schedule,
+            git_repo_url,
             git_repo_branch,
             retries,
             history_limit,
         )
     elif command == "delete":
-        load_kubernetes_config()
         delete_workflow_cronjob_in_namespace(BODYWORK_DEPLOYMENT_JOBS_NAMESPACE, name)
     elif command == "history":
-        load_kubernetes_config()
         display_workflow_job_history(BODYWORK_DEPLOYMENT_JOBS_NAMESPACE, name)
     elif command == "logs":
-        load_kubernetes_config()
         display_workflow_job_logs(BODYWORK_DEPLOYMENT_JOBS_NAMESPACE, name)
     else:
-        load_kubernetes_config()
         display_cronjobs_in_namespace(BODYWORK_DEPLOYMENT_JOBS_NAMESPACE)
     sys.exit(0)
 

--- a/src/bodywork/cli/cli.py
+++ b/src/bodywork/cli/cli.py
@@ -381,9 +381,9 @@ def deployment(args: Namespace) -> None:
                 sys.exit(1)
             create_workflow_job_in_namespace(
                 BODYWORK_DEPLOYMENT_JOBS_NAMESPACE,
+                name,
                 git_repo_url,
                 git_repo_branch,
-                name,
                 retries,
             )
     elif command == "logs":

--- a/src/bodywork/cli/workflow_jobs.py
+++ b/src/bodywork/cli/workflow_jobs.py
@@ -19,6 +19,7 @@ This module contains functions for managing Kubernetes workflow jobs.
 They are targeted for use via the CLI.
 """
 import re
+from typing import Optional
 
 from .. import k8s
 
@@ -45,7 +46,7 @@ def create_workflow_job_in_namespace(
     if not k8s.namespace_exists(namespace):
         print(f"namespace={namespace} could not be found on k8s cluster")
         return None
-    if job_name and _is_existing_workflow_job(namespace, job_name):
+    if _is_existing_workflow_job(namespace, job_name):
         print(f"workflow job={job_name} already exists in namespace={namespace}")
         return None
     configured_job = k8s.configure_workflow_job(
@@ -121,11 +122,11 @@ def create_workflow_cronjob(
 def update_workflow_cronjob_in_namespace(
     namespace: str,
     job_name: str,
-    schedule: str = None,
-    project_repo_url: str = None,
-    project_repo_branch: str = None,
-    retries: int = None,
-    workflow_job_history_limit: int = None,
+    schedule: Optional[str] = None,
+    project_repo_url: Optional[str] = None,
+    project_repo_branch: Optional[str] = None,
+    retries: Optional[int] = None,
+    workflow_job_history_limit: Optional[int] = None,
 ) -> None:
     """Update a new cronjob within a namespace.
 

--- a/src/bodywork/cli/workflow_jobs.py
+++ b/src/bodywork/cli/workflow_jobs.py
@@ -49,7 +49,7 @@ def create_workflow_job_in_namespace(
         print(f"workflow job={job_name} already exists in namespace={namespace}")
         return None
     configured_job = k8s.configure_workflow_job(
-        namespace, project_repo_url, project_repo_branch, retries
+        namespace, project_repo_url, project_repo_branch, retries, job_name=job_name
     )
     k8s.create_workflow_job(configured_job)
     print(f"workflow job={job_name} created in namespace={namespace}")

--- a/src/bodywork/cli/workflow_jobs.py
+++ b/src/bodywork/cli/workflow_jobs.py
@@ -25,9 +25,9 @@ from .. import k8s
 
 def create_workflow_job_in_namespace(
     namespace: str,
+    job_name: str,
     project_repo_url: str,
     project_repo_branch: str = "master",
-    job_name: str = None,
     retries: int = 2,
 ) -> None:
     """Create a new workflow job within a namespace.

--- a/src/bodywork/cli/workflow_jobs.py
+++ b/src/bodywork/cli/workflow_jobs.py
@@ -96,14 +96,10 @@ def create_workflow_cronjob(
         historical workflow jobs, so logs can be retrieved.
     """
     if not k8s.namespace_exists(namespace):
-        print(
-            f"namespace={namespace} could not be found on k8s cluster."    # noqa
-        )
+        print(f"namespace={namespace} could not be found on k8s cluster.")  # noqa
         return None
     if _is_existing_workflow_cronjob(namespace, job_name):
-        print(
-            f"cronjob={job_name} already exists in {namespace} namespace." # noqa
-        )
+        print(f"cronjob={job_name} already exists in {namespace} namespace.")  # noqa
         return None
     if not _is_valid_cron_schedule(schedule):
         print(f"schedule={schedule} is not a valid cron schedule")
@@ -119,9 +115,53 @@ def create_workflow_cronjob(
         workflow_job_history_limit,
     )
     k8s.create_workflow_cronjob(configured_job)
-    print(
-        f"workflow cronjob={job_name} created in {namespace} namespace."   # noqa
+    print(f"workflow cronjob={job_name} created in {namespace} namespace.")  # noqa
+
+
+def update_workflow_cronjob_in_namespace(
+    namespace: str,
+    job_name: str,
+    schedule: str = None,
+    project_repo_url: str = None,
+    project_repo_branch: str = None,
+    retries: int = None,
+    workflow_job_history_limit: int = None,
+) -> None:
+    """Update a new cronjob within a namespace.
+
+    :param namespace: The namespace the job resides in.
+    :param job_name: The name of the cronjob.
+    :param schedule: A valid cron schedule definition.
+    :param project_repo_url: The URL for the Bodywork project Git
+        repository.
+    :param project_repo_branch: The branch of the Bodywork project Git
+        repository that will be used as the executable codebase,
+        defaults to 'master'.
+    :param retries: Number of times to retry running the stage to
+        completion (if necessary), defaults to 2.
+    :param workflow_job_history_limit: Minimum number of
+        historical workflow jobs, so logs can be retrieved.
+    """
+    if not k8s.namespace_exists(namespace):
+        print(f"namespace={namespace} could not be found on k8s cluster.")  # noqa
+        return None
+    if not _is_existing_workflow_cronjob(namespace, job_name):
+        print(f"cronjob={job_name} not found in namespace={namespace}")
+        return None
+    if schedule and not _is_valid_cron_schedule(schedule):
+        print(f"schedule={schedule} is not a valid cron schedule")
+        return None
+    k8s.update_workflow_cronjob(
+        namespace,
+        job_name,
+        schedule,
+        project_repo_url,
+        project_repo_branch,
+        retries,
+        workflow_job_history_limit,
+        workflow_job_history_limit,
     )
+    print(f"workflow cronjob={job_name} updated in {namespace} namespace.")
 
 
 def delete_workflow_cronjob_in_namespace(namespace: str, job_name: str) -> None:

--- a/src/bodywork/cli/workflow_jobs.py
+++ b/src/bodywork/cli/workflow_jobs.py
@@ -45,7 +45,7 @@ def create_workflow_job_in_namespace(
     if not k8s.namespace_exists(namespace):
         print(f"namespace={namespace} could not be found on k8s cluster")
         return None
-    if _is_existing_workflow_job(namespace, job_name):
+    if job_name and _is_existing_workflow_job(namespace, job_name):
         print(f"workflow job={job_name} already exists in namespace={namespace}")
         return None
     configured_job = k8s.configure_workflow_job(

--- a/src/bodywork/cli/workflow_jobs.py
+++ b/src/bodywork/cli/workflow_jobs.py
@@ -25,9 +25,9 @@ from .. import k8s
 
 def create_workflow_job_in_namespace(
     namespace: str,
-    job_name: str,
     project_repo_url: str,
     project_repo_branch: str = "master",
+    job_name: str = None,
     retries: int = 2,
 ) -> None:
     """Create a new workflow job within a namespace.

--- a/src/bodywork/k8s/__init__.py
+++ b/src/bodywork/k8s/__init__.py
@@ -38,6 +38,7 @@ from .workflow_jobs import (
     delete_workflow_cronjob,
     list_workflow_cronjobs,
     list_workflow_jobs,
+    update_workflow_cronjob,
 )
 from .batch_jobs import (
     JobStatus,

--- a/src/bodywork/k8s/__init__.py
+++ b/src/bodywork/k8s/__init__.py
@@ -133,4 +133,5 @@ __all__ = [
     "create_k8s_environment_variables",
     "EnvVars",
     "replicate_secrets_in_namespace",
+    "update_workflow_cronjob",
 ]

--- a/src/bodywork/k8s/workflow_jobs.py
+++ b/src/bodywork/k8s/workflow_jobs.py
@@ -91,9 +91,7 @@ def configure_workflow_job(
         job_name = _create_job_name(project_repo_url, project_repo_branch)
     job = k8s.V1Job(
         metadata=k8s.V1ObjectMeta(
-            name=make_valid_k8s_name(
-                job_name
-            ),
+            name=make_valid_k8s_name(job_name),
             namespace=namespace,
             labels={"app": "bodywork"},
         ),
@@ -183,6 +181,70 @@ def create_workflow_cronjob(cron_job: k8s.V1Job) -> None:
     k8s.BatchV1beta1Api().create_namespaced_cron_job(
         body=cron_job, namespace=cron_job.metadata.namespace
     )
+
+
+def update_workflow_cronjob(
+    namespace: str,
+    name: str,
+    schedule: str = None,
+    project_repo_url: str = None,
+    project_repo_branch: str = None,
+    retries: int = None,
+    successful_jobs_history_limit: int = None,
+    failed_jobs_history_limit: int = None,
+) -> None:
+    """Update a Bodywork workflow cronjob.
+
+    :param name: The name  of the cronjob.
+    :param namespace: Namespace the cronjob resides in.
+    :param schedule: A valid cron schedule definition.
+    :param project_repo_url: The URL for the Bodywork project Git
+        repository.
+    :param project_repo_branch: The Bodywork project Git repository
+        branch to use, defaults to 'master'.
+    :param retries: Number of times to retry running the stage to
+        completion (if necessary), defaults to 2.
+    :param successful_jobs_history_limit: The number of successful job
+        runs (pods) to keep, defaults to 1.
+    :param failed_jobs_history_limit: The number of unsuccessful job
+        runs (pods) to keep, defaults to 1.
+    """
+
+    if not schedule:
+        schedule = (
+            k8s.BatchV1beta1Api()
+            .read_namespaced_cron_job(name, namespace)
+            .spec.schedule
+        )
+
+    if project_repo_url and project_repo_branch:
+        pod_spec = k8s.V1PodSpec(
+            containers=[
+                k8s.V1Container(
+                    name="bodywork", args=[project_repo_url, project_repo_branch]
+                )
+            ],
+        )
+        job = k8s.V1Job(
+            spec=k8s.V1JobSpec(
+                template=k8s.V1PodTemplateSpec(spec=pod_spec),
+                backoff_limit=retries,
+            )
+        )
+        job_template = k8s.V1beta1JobTemplateSpec(spec=job.spec)
+    else:
+        job_template = k8s.V1beta1JobTemplateSpec()
+
+    cronjob = k8s.V1beta1CronJob(
+        spec=k8s.V1beta1CronJobSpec(
+            job_template=job_template,
+            schedule=schedule,
+            successful_jobs_history_limit=successful_jobs_history_limit,
+            failed_jobs_history_limit=failed_jobs_history_limit,
+        )
+    )
+
+    k8s.BatchV1beta1Api().patch_namespaced_cron_job(name, namespace, cronjob)
 
 
 def delete_workflow_cronjob(namespace: str, name: str) -> None:

--- a/src/bodywork/k8s/workflow_jobs.py
+++ b/src/bodywork/k8s/workflow_jobs.py
@@ -21,7 +21,7 @@ to create and manage cronjobs that execute Bodywork project workflows.
 import os
 import random
 from datetime import datetime
-from typing import Dict, Union
+from typing import Dict, Union, Optional
 
 from kubernetes import client as k8s
 
@@ -186,12 +186,12 @@ def create_workflow_cronjob(cron_job: k8s.V1Job) -> None:
 def update_workflow_cronjob(
     namespace: str,
     name: str,
-    schedule: str = None,
-    project_repo_url: str = None,
-    project_repo_branch: str = None,
-    retries: int = None,
-    successful_jobs_history_limit: int = None,
-    failed_jobs_history_limit: int = None,
+    schedule: Optional[str] = None,
+    project_repo_url: Optional[str] = None,
+    project_repo_branch: Optional[str] = None,
+    retries: Optional[int] = None,
+    successful_jobs_history_limit: Optional[int] = None,
+    failed_jobs_history_limit: Optional[int] = None,
 ) -> None:
     """Update a Bodywork workflow cronjob.
 

--- a/tests/integration/test_k8s_with_cluster.py
+++ b/tests/integration/test_k8s_with_cluster.py
@@ -58,14 +58,14 @@ def test_workflow_and_service_management_end_to_end_from_cli(
         expected_output_1 = (
             "attempting to run workflow for "
             "project=https://github.com/bodywork-ml/bodywork-test-project on "
-            f"branch=master"
+            "branch=master"
         )
         expected_output_2 = "successfully ran stage=stage_1"
         expected_output_3 = "attempting to run stage=stage_4"
         expected_output_4 = (
             "successfully ran workflow for "
             "project=https://github.com/bodywork-ml/bodywork-test-project on "
-            f"branch=master"
+            "branch=master"
         )
         expected_output_5 = "successfully ran stage=stage_5"
         assert expected_output_1 in process_one.stdout
@@ -89,24 +89,24 @@ def test_workflow_and_service_management_end_to_end_from_cli(
         assert process_two.returncode == 0
 
         process_three = run(
-            ["bodywork", "service", "display", f"--namespace=bodywork-test-project"],
+            ["bodywork", "service", "display", "--namespace=bodywork-test-project"],
             encoding="utf-8",
             capture_output=True,
         )
         assert (
-            f"http://bodywork-test-project--stage-3.bodywork-test-project.svc"
+            "http://bodywork-test-project--stage-3.bodywork-test-project.svc"
             in process_three.stdout
         )
         assert (
-            f"http://bodywork-test-project--stage-4.bodywork-test-project.svc"
+            "http://bodywork-test-project--stage-4.bodywork-test-project.svc"
             in process_three.stdout
         )
         assert (
-            f"/bodywork-test-project/bodywork-test-project--stage-3"
+            "/bodywork-test-project/bodywork-test-project--stage-3"
             in process_three.stdout
         )
         assert (
-            f"/bodywork-test-project/bodywork-test-project--stage-4"
+            "/bodywork-test-project/bodywork-test-project--stage-4"
             not in process_three.stdout
         )
         assert "5000" in process_three.stdout
@@ -133,7 +133,7 @@ def test_workflow_and_service_management_end_to_end_from_cli(
                 "bodywork",
                 "service",
                 "delete",
-                f"--namespace=bodywork-test-project",
+                "--namespace=bodywork-test-project",
                 "--name=bodywork-test-project--stage-3",
             ],
             encoding="utf-8",
@@ -143,11 +143,11 @@ def test_workflow_and_service_management_end_to_end_from_cli(
             "deployment=bodywork-test-project--stage-3 deleted" in process_four.stdout
         )
         assert (
-            f"service at http://bodywork-test-project--stage-3.bodywork-test-project.svc.cluster.local deleted"  # noqa
+            "service at http://bodywork-test-project--stage-3.bodywork-test-project.svc.cluster.local deleted"  # noqa
             in process_four.stdout
         )  # noqa
         assert (
-            f"ingress route /bodywork-test-project/bodywork-test-project--stage-3 deleted"  # noqa
+            "ingress route /bodywork-test-project/bodywork-test-project--stage-3 deleted"  # noqa
             in process_four.stdout
         )
         assert process_four.returncode == 0
@@ -157,7 +157,7 @@ def test_workflow_and_service_management_end_to_end_from_cli(
                 "bodywork",
                 "service",
                 "delete",
-                f"--namespace=bodywork-test-project",
+                "--namespace=bodywork-test-project",
                 "--name=bodywork-test-project--stage-4",
             ],
             encoding="utf-8",
@@ -165,17 +165,17 @@ def test_workflow_and_service_management_end_to_end_from_cli(
         )
         assert "deployment=bodywork-test-project--stage-4 deleted" in process_five.stdout
         assert (
-            f"service at http://bodywork-test-project--stage-4.bodywork-test-project.svc.cluster.local deleted"  # noqa
+            "service at http://bodywork-test-project--stage-4.bodywork-test-project.svc.cluster.local deleted"  # noqa
             in process_five.stdout
         )  # noqa
         assert (
-            f"ingress route /bodywork-test-project/bodywork-test-project--stage-4 deleted"  # noqa
+            "ingress route /bodywork-test-project/bodywork-test-project--stage-4 deleted"  # noqa
             not in process_five.stdout
         )  # noqa
         assert process_five.returncode == 0
 
         process_six = run(
-            ["bodywork", "service", "display", f"--namespace=bodywork-test-project"],
+            ["bodywork", "service", "display", "--namespace=bodywork-test-project"],
             encoding="utf-8",
             capture_output=True,
         )
@@ -329,12 +329,12 @@ def test_workflow_with_ssh_github_connectivity(
         expected_output_1 = (
             "attempting to run workflow for "
             "project=git@github.com:bodywork-ml/bodywork-test-project.git on "
-            f"branch=master"
+            "branch=master"
         )
         expected_output_2 = (
             "successfully ran workflow for "
             "project=git@github.com:bodywork-ml/bodywork-test-project.git on "
-            f"branch=master"
+            "branch=master"
         )
         expected_output_3 = "successfully ran stage=stage_1"
         assert expected_output_1 in process_one.stdout
@@ -402,7 +402,7 @@ def test_deployment_of_remote_workflows():
 
 
 @mark.usefixtures("setup_cluster")
-def test_cli_cronjob_handler_crud(test_namespace: str):
+def test_cli_cronjob_handler_crud():
     process_one = run(
         [
             "bodywork",
@@ -421,17 +421,33 @@ def test_cli_cronjob_handler_crud(test_namespace: str):
     assert process_one.returncode == 0
 
     process_two = run(
+        [
+            "bodywork",
+            "cronjob",
+            "update",
+            "--name=bodywork-test-project",
+            "--schedule=0,0 1 * * *",
+            "--git-repo-url=https://github.com/bodywork-ml/bodywork-test-project",
+            "--git-repo-branch=main"
+        ],
+        encoding="utf-8",
+        capture_output=True,
+    )
+    assert "cronjob=bodywork-test-project updated" in process_two.stdout
+    assert process_two.returncode == 0
+
+    process_three = run(
         ["bodywork", "cronjob", "display"],
         encoding="utf-8",
         capture_output=True,
     )
-    assert "bodywork-test-project" in process_two.stdout
-    assert "0,30 * * * *" in process_two.stdout
-    assert "https://github.com/bodywork-ml/bodywork-test-project" in process_two.stdout
-    assert "master" in process_two.stdout
-    assert process_two.returncode == 0
+    assert "bodywork-test-project" in process_three.stdout
+    assert "0,0 1 * * *" in process_three.stdout
+    assert "https://github.com/bodywork-ml/bodywork-test-project" in process_three.stdout
+    assert "main" in process_three.stdout
+    assert process_three.returncode == 0
 
-    process_three = run(
+    process_four = run(
         [
             "bodywork",
             "cronjob",
@@ -441,16 +457,16 @@ def test_cli_cronjob_handler_crud(test_namespace: str):
         encoding="utf-8",
         capture_output=True,
     )
-    assert "cronjob=bodywork-test-project deleted" in process_three.stdout
-    assert process_three.returncode == 0
+    assert "cronjob=bodywork-test-project deleted" in process_four.stdout
+    assert process_four.returncode == 0
 
-    process_four = run(
+    process_five = run(
         ["bodywork", "cronjob", "display"],
         encoding="utf-8",
         capture_output=True,
     )
-    assert "" in process_four.stdout
-    assert process_four.returncode == 0
+    assert "" in process_five.stdout
+    assert process_five.returncode == 0
 
 
 def test_workflow_command_unsuccessful_raises_exception(test_namespace: str):

--- a/tests/unit_and_functional/test_cli.py
+++ b/tests/unit_and_functional/test_cli.py
@@ -334,7 +334,7 @@ def test_cli_cronjob_handler_error_handling():
 
 
 def test_cronjob_update_error_handling():
-    process_seven = run(
+    process_one = run(
         [
             "bodywork",
             "cronjob",
@@ -347,9 +347,9 @@ def test_cronjob_update_error_handling():
     )
     assert (
         "Please specify both --git-repo-url and --git-repo-branch."
-        in process_seven.stdout
+        in process_one.stdout
     )
-    assert process_seven.returncode == 1
+    assert process_one.returncode == 1
 
 
 def test_services_subcommand_exists():

--- a/tests/unit_and_functional/test_cli.py
+++ b/tests/unit_and_functional/test_cli.py
@@ -205,7 +205,9 @@ def test_cli_secret_handler_error_handling():
         encoding="utf-8",
         capture_output=True,
     )
-    assert "please specify the secret group the secret belongs to" in process_five.stdout
+    assert (
+        "please specify the secret group the secret belongs to" in process_five.stdout
+    )
 
 
 def test_deployment_subcommand_exists():
@@ -329,6 +331,25 @@ def test_cli_cronjob_handler_error_handling():
     )
     assert "please specify Git repo URL" in process_six.stdout
     assert process_six.returncode == 1
+
+
+def test_cronjob_update_error_handling():
+    process_seven = run(
+        [
+            "bodywork",
+            "cronjob",
+            "update",
+            "--name=the-cronjob",
+            "--git-repo-url=https://test",
+        ],
+        encoding="utf-8",
+        capture_output=True,
+    )
+    assert (
+        "Please specify both --git-repo-url and --git-repo-branch."
+        in process_seven.stdout
+    )
+    assert process_seven.returncode == 1
 
 
 def test_services_subcommand_exists():

--- a/tests/unit_and_functional/test_k8s_workflow_jobs.py
+++ b/tests/unit_and_functional/test_k8s_workflow_jobs.py
@@ -98,7 +98,7 @@ def test_configure_workflow_job(mock_random: MagicMock):
     )
 
 
-@patch("bodywork.k8s.workflow_jobs.k8s.BatchV1beta1Api")
+@patch("bodywork.k8s.workflow_jobs.k8s.BatchV1Api")
 def test_create_workflow_job_tries_to_create_workflow_job_with_k8s_api(
     mock_k8s_batchv1_api: MagicMock, workflow_job_object: k8s.V1Job
 ):

--- a/tests/unit_and_functional/test_k8s_workflow_jobs.py
+++ b/tests/unit_and_functional/test_k8s_workflow_jobs.py
@@ -98,7 +98,7 @@ def test_configure_workflow_job(mock_random: MagicMock):
     )
 
 
-@patch("k8s.BatchV1Api")
+@patch("bodywork.k8s.workflow_jobs.k8s.BatchV1beta1Api")
 def test_create_workflow_job_tries_to_create_workflow_job_with_k8s_api(
     mock_k8s_batchv1_api: MagicMock, workflow_job_object: k8s.V1Job
 ):
@@ -235,7 +235,7 @@ def test_list_workflow_cronjobs_returns_cronjobs_summary_info(
     )
 
 
-@patch("k8s.BatchV1Api")
+@patch("bodywork.k8s.workflow_jobs.k8s.BatchV1beta1Api")
 def test_list_workflow_jobs_returns_jobs_summary_info(
     mock_k8s_batchv1_api: MagicMock,
 ):

--- a/tests/unit_and_functional/test_k8s_workflow_jobs.py
+++ b/tests/unit_and_functional/test_k8s_workflow_jobs.py
@@ -22,7 +22,7 @@ project workflows.
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
-import kubernetes.client as k8s
+import kubernetes.client as k8s_client
 from pytest import fixture
 
 from bodywork.constants import (
@@ -42,24 +42,24 @@ from bodywork.k8s.workflow_jobs import (
 
 
 @fixture(scope="session")
-def workflow_job_object() -> k8s.V1Job:
-    container = k8s.V1Container(
+def workflow_job_object() -> k8s_client.V1Job:
+    container = k8s_client.V1Container(
         name="bodywork",
         image="bodyworkml/bodywork-core:latest",
         image_pull_policy="Always",
         command=["bodywork", "workflow"],
         args=["bodywork-dev", "project_repo_url", "project_repo_branch"],
     )
-    pod_spec = k8s.V1PodSpec(containers=[container], restart_policy="Never")
-    pod_template_spec = k8s.V1PodTemplateSpec(spec=pod_spec)
-    job_spec = k8s.V1JobSpec(
+    pod_spec = k8s_client.V1PodSpec(containers=[container], restart_policy="Never")
+    pod_template_spec = k8s_client.V1PodTemplateSpec(spec=pod_spec)
+    job_spec = k8s_client.V1JobSpec(
         template=pod_template_spec,
         completions=1,
         backoff_limit=2,
         ttl_seconds_after_finished=BODYWORK_WORKFLOW_JOB_TIME_TO_LIVE,
     )
-    job = k8s.V1Job(
-        metadata=k8s.V1ObjectMeta(
+    job = k8s_client.V1Job(
+        metadata=k8s_client.V1ObjectMeta(
             name="bodywork-test-project", namespace="bodywork-dev"
         ),
         spec=job_spec,
@@ -100,7 +100,7 @@ def test_configure_workflow_job(mock_random: MagicMock):
 
 @patch("bodywork.k8s.workflow_jobs.k8s.BatchV1Api")
 def test_create_workflow_job_tries_to_create_workflow_job_with_k8s_api(
-    mock_k8s_batchv1_api: MagicMock, workflow_job_object: k8s.V1Job
+    mock_k8s_batchv1_api: MagicMock, workflow_job_object: k8s_client.V1Job
 ):
     create_workflow_job(workflow_job_object)
     mock_k8s_batchv1_api().create_namespaced_job.assert_called_once_with(
@@ -109,30 +109,30 @@ def test_create_workflow_job_tries_to_create_workflow_job_with_k8s_api(
 
 
 @fixture(scope="session")
-def workflow_cronjob_object() -> k8s.V1Job:
-    container = k8s.V1Container(
+def workflow_cronjob_object() -> k8s_client.V1Job:
+    container = k8s_client.V1Container(
         name="bodywork",
         image="bodyworkml/bodywork-core:latest",
         image_pull_policy="Always",
         command=["bodywork", "workflow"],
         args=["project_repo_url", "project_repo_branch"],
     )
-    pod_spec = k8s.V1PodSpec(containers=[container], restart_policy="Never")
-    pod_template_spec = k8s.V1PodTemplateSpec(spec=pod_spec)
-    job_spec = k8s.V1JobSpec(template=pod_template_spec, completions=1, backoff_limit=2)
-    job_template = k8s.V1beta1JobTemplateSpec(spec=job_spec)
-    cronjob_spec = k8s.V1beta1CronJobSpec(
+    pod_spec = k8s_client.V1PodSpec(containers=[container], restart_policy="Never")
+    pod_template_spec = k8s_client.V1PodTemplateSpec(spec=pod_spec)
+    job_spec = k8s_client.V1JobSpec(template=pod_template_spec, completions=1, backoff_limit=2)
+    job_template = k8s_client.V1beta1JobTemplateSpec(spec=job_spec)
+    cronjob_spec = k8s_client.V1beta1CronJobSpec(
         schedule="0,30 * * * *",
         successful_jobs_history_limit=2,
         failed_jobs_history_limit=2,
         job_template=job_template,
     )
-    cronjob = k8s.V1beta1CronJob(
-        metadata=k8s.V1ObjectMeta(
+    cronjob = k8s_client.V1beta1CronJob(
+        metadata=k8s_client.V1ObjectMeta(
             name="bodywork-test-project", namespace="bodywork-dev"
         ),
         spec=cronjob_spec,
-        status=k8s.V1beta1CronJobStatus(last_schedule_time=datetime(2020, 9, 15)),
+        status=k8s_client.V1beta1CronJobStatus(last_schedule_time=datetime(2020, 9, 15)),
     )
     return cronjob
 
@@ -167,7 +167,7 @@ def test_configure_workflow_cronjob():
 @patch("bodywork.k8s.workflow_jobs.k8s.BatchV1beta1Api")
 def test_create_workflow_cronjob_tries_to_create_job_with_k8s_api(
     mock_k8s_batchv1beta1_api: MagicMock,
-    workflow_cronjob_object: k8s.V1beta1CronJob,
+    workflow_cronjob_object: k8s_client.V1beta1CronJob,
 ):
     create_workflow_cronjob(workflow_cronjob_object)
     mock_k8s_batchv1beta1_api().create_namespaced_cron_job.assert_called_once_with(
@@ -179,16 +179,16 @@ def test_create_workflow_cronjob_tries_to_create_job_with_k8s_api(
 def test_updates_workflow_cronjob_updates_cronjob_with_k8s_api(
     mock_k8s_batchv1beta1_api: MagicMock,
 ):
-    pod_spec = k8s.V1PodSpec(
-        containers=[k8s.V1Container(name="bodywork", args=["fg", "test-branch"])],
+    pod_spec = k8s_client.V1PodSpec(
+        containers=[k8s_client.V1Container(name="bodywork", args=["fg", "test-branch"])],
     )
-    job_spec = k8s.V1JobSpec(
-        template=k8s.V1PodTemplateSpec(spec=pod_spec),
+    job_spec = k8s_client.V1JobSpec(
+        template=k8s_client.V1PodTemplateSpec(spec=pod_spec),
         backoff_limit=3,
     )
-    job_template = k8s.V1beta1JobTemplateSpec(spec=k8s.V1Job(spec=job_spec).spec)
-    expected_result = k8s.V1beta1CronJob(
-        spec=k8s.V1beta1CronJobSpec(
+    job_template = k8s_client.V1beta1JobTemplateSpec(spec=k8s_client.V1Job(spec=job_spec).spec)
+    expected_result = k8s_client.V1beta1CronJob(
+        spec=k8s_client.V1beta1CronJobSpec(
             job_template=job_template,
             schedule="0 0 * * *",
             successful_jobs_history_limit=1,
@@ -213,17 +213,17 @@ def test_delete_workflow_cronjob_tries_to_delete_job_with_k8s_api(
     mock_k8s_batchv1beta1_api().delete_namespaced_cron_job.assert_called_once_with(
         name="bodywork-test-project",
         namespace="bodywork-dev",
-        body=k8s.V1DeleteOptions(propagation_policy="Background"),
+        body=k8s_client.V1DeleteOptions(propagation_policy="Background"),
     )
 
 
 @patch("bodywork.k8s.workflow_jobs.k8s.BatchV1beta1Api")
 def test_list_workflow_cronjobs_returns_cronjobs_summary_info(
     mock_k8s_batchv1beta1_api: MagicMock,
-    workflow_cronjob_object: k8s.V1beta1CronJob,
+    workflow_cronjob_object: k8s_client.V1beta1CronJob,
 ):
     mock_k8s_batchv1beta1_api().list_namespaced_cron_job.return_value = (
-        k8s.V1beta1CronJobList(items=[workflow_cronjob_object])
+        k8s_client.V1beta1CronJobList(items=[workflow_cronjob_object])
     )
     cronjobs = list_workflow_cronjobs("bodywork-dev")
     assert cronjobs["bodywork-test-project"]["schedule"] == "0,30 * * * *"
@@ -239,11 +239,11 @@ def test_list_workflow_cronjobs_returns_cronjobs_summary_info(
 def test_list_workflow_jobs_returns_jobs_summary_info(
     mock_k8s_batchv1_api: MagicMock,
 ):
-    mock_k8s_batchv1_api().list_namespaced_job.return_value = k8s.V1JobList(
+    mock_k8s_batchv1_api().list_namespaced_job.return_value = k8s_client.V1JobList(
         items=[
-            k8s.V1Job(
-                metadata=k8s.V1ObjectMeta(name="workflow-job-12345"),
-                status=k8s.V1JobStatus(
+            k8s_client.V1Job(
+                metadata=k8s_client.V1ObjectMeta(name="workflow-job-12345"),
+                status=k8s_client.V1JobStatus(
                     start_time=datetime(2020, 10, 19, 12, 15),
                     completion_time=None,
                     active=1,
@@ -251,9 +251,9 @@ def test_list_workflow_jobs_returns_jobs_summary_info(
                     failed=0,
                 ),
             ),
-            k8s.V1Job(
-                metadata=k8s.V1ObjectMeta(name="workflow-job-6789"),
-                status=k8s.V1JobStatus(
+            k8s_client.V1Job(
+                metadata=k8s_client.V1ObjectMeta(name="workflow-job-6789"),
+                status=k8s_client.V1JobStatus(
                     start_time=datetime(2020, 10, 19, 13, 15),
                     completion_time=datetime(2020, 10, 19, 13, 30),
                     active=0,
@@ -261,9 +261,9 @@ def test_list_workflow_jobs_returns_jobs_summary_info(
                     failed=0,
                 ),
             ),
-            k8s.V1Job(
-                metadata=k8s.V1ObjectMeta(name="batch-job-12345"),
-                status=k8s.V1JobStatus(
+            k8s_client.V1Job(
+                metadata=k8s_client.V1ObjectMeta(name="batch-job-12345"),
+                status=k8s_client.V1JobStatus(
                     start_time=datetime(2020, 10, 19, 12, 16),
                     completion_time=datetime(2020, 10, 19, 12, 17),
                     active=0,

--- a/tests/unit_and_functional/test_k8s_workflow_jobs.py
+++ b/tests/unit_and_functional/test_k8s_workflow_jobs.py
@@ -235,7 +235,7 @@ def test_list_workflow_cronjobs_returns_cronjobs_summary_info(
     )
 
 
-@patch("bodywork.k8s.workflow_jobs.k8s.BatchV1beta1Api")
+@patch("bodywork.k8s.workflow_jobs.k8s.BatchV1Api")
 def test_list_workflow_jobs_returns_jobs_summary_info(
     mock_k8s_batchv1_api: MagicMock,
 ):

--- a/tests/unit_and_functional/test_k8s_workflow_jobs.py
+++ b/tests/unit_and_functional/test_k8s_workflow_jobs.py
@@ -22,7 +22,7 @@ project workflows.
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
-import kubernetes
+import kubernetes.client as k8s
 from pytest import fixture
 
 from bodywork.constants import (
@@ -37,30 +37,29 @@ from bodywork.k8s.workflow_jobs import (
     delete_workflow_cronjob,
     list_workflow_cronjobs,
     list_workflow_jobs,
+    update_workflow_cronjob,
 )
 
 
 @fixture(scope="session")
-def workflow_job_object() -> kubernetes.client.V1Job:
-    container = kubernetes.client.V1Container(
+def workflow_job_object() -> k8s.V1Job:
+    container = k8s.V1Container(
         name="bodywork",
         image="bodyworkml/bodywork-core:latest",
         image_pull_policy="Always",
         command=["bodywork", "workflow"],
         args=["bodywork-dev", "project_repo_url", "project_repo_branch"],
     )
-    pod_spec = kubernetes.client.V1PodSpec(
-        containers=[container], restart_policy="Never"
-    )
-    pod_template_spec = kubernetes.client.V1PodTemplateSpec(spec=pod_spec)
-    job_spec = kubernetes.client.V1JobSpec(
+    pod_spec = k8s.V1PodSpec(containers=[container], restart_policy="Never")
+    pod_template_spec = k8s.V1PodTemplateSpec(spec=pod_spec)
+    job_spec = k8s.V1JobSpec(
         template=pod_template_spec,
         completions=1,
         backoff_limit=2,
         ttl_seconds_after_finished=BODYWORK_WORKFLOW_JOB_TIME_TO_LIVE,
     )
-    job = kubernetes.client.V1Job(
-        metadata=kubernetes.client.V1ObjectMeta(
+    job = k8s.V1Job(
+        metadata=k8s.V1ObjectMeta(
             name="bodywork-test-project", namespace="bodywork-dev"
         ),
         spec=job_spec,
@@ -99,9 +98,9 @@ def test_configure_workflow_job(mock_random: MagicMock):
     )
 
 
-@patch("kubernetes.client.BatchV1Api")
+@patch("k8s.BatchV1Api")
 def test_create_workflow_job_tries_to_create_workflow_job_with_k8s_api(
-    mock_k8s_batchv1_api: MagicMock, workflow_job_object: kubernetes.client.V1Job
+    mock_k8s_batchv1_api: MagicMock, workflow_job_object: k8s.V1Job
 ):
     create_workflow_job(workflow_job_object)
     mock_k8s_batchv1_api().create_namespaced_job.assert_called_once_with(
@@ -110,36 +109,30 @@ def test_create_workflow_job_tries_to_create_workflow_job_with_k8s_api(
 
 
 @fixture(scope="session")
-def workflow_cronjob_object() -> kubernetes.client.V1Job:
-    container = kubernetes.client.V1Container(
+def workflow_cronjob_object() -> k8s.V1Job:
+    container = k8s.V1Container(
         name="bodywork",
         image="bodyworkml/bodywork-core:latest",
         image_pull_policy="Always",
         command=["bodywork", "workflow"],
         args=["project_repo_url", "project_repo_branch"],
     )
-    pod_spec = kubernetes.client.V1PodSpec(
-        containers=[container], restart_policy="Never"
-    )
-    pod_template_spec = kubernetes.client.V1PodTemplateSpec(spec=pod_spec)
-    job_spec = kubernetes.client.V1JobSpec(
-        template=pod_template_spec, completions=1, backoff_limit=2
-    )
-    job_template = kubernetes.client.V1beta1JobTemplateSpec(spec=job_spec)
-    cronjob_spec = kubernetes.client.V1beta1CronJobSpec(
+    pod_spec = k8s.V1PodSpec(containers=[container], restart_policy="Never")
+    pod_template_spec = k8s.V1PodTemplateSpec(spec=pod_spec)
+    job_spec = k8s.V1JobSpec(template=pod_template_spec, completions=1, backoff_limit=2)
+    job_template = k8s.V1beta1JobTemplateSpec(spec=job_spec)
+    cronjob_spec = k8s.V1beta1CronJobSpec(
         schedule="0,30 * * * *",
         successful_jobs_history_limit=2,
         failed_jobs_history_limit=2,
         job_template=job_template,
     )
-    cronjob = kubernetes.client.V1beta1CronJob(
-        metadata=kubernetes.client.V1ObjectMeta(
+    cronjob = k8s.V1beta1CronJob(
+        metadata=k8s.V1ObjectMeta(
             name="bodywork-test-project", namespace="bodywork-dev"
         ),
         spec=cronjob_spec,
-        status=kubernetes.client.V1beta1CronJobStatus(
-            last_schedule_time=datetime(2020, 9, 15)
-        ),
+        status=k8s.V1beta1CronJobStatus(last_schedule_time=datetime(2020, 9, 15)),
     )
     return cronjob
 
@@ -157,7 +150,7 @@ def test_configure_workflow_cronjob():
         job_name="test-job",
     )
     assert cronjob_definition.metadata.namespace == "bodywork-deployment-jobs"
-    assert cronjob_definition.metadata.name == f"test-job"
+    assert cronjob_definition.metadata.name == "test-job"
     assert cronjob_definition.spec.schedule == "0,30 * * * *"
     assert cronjob_definition.spec.successful_jobs_history_limit == 2
     assert cronjob_definition.spec.failed_jobs_history_limit == 2
@@ -171,10 +164,10 @@ def test_configure_workflow_cronjob():
     )
 
 
-@patch("kubernetes.client.BatchV1beta1Api")
+@patch("bodywork.k8s.workflow_jobs.k8s.BatchV1beta1Api")
 def test_create_workflow_cronjob_tries_to_create_job_with_k8s_api(
     mock_k8s_batchv1beta1_api: MagicMock,
-    workflow_cronjob_object: kubernetes.client.V1beta1CronJob,
+    workflow_cronjob_object: k8s.V1beta1CronJob,
 ):
     create_workflow_cronjob(workflow_cronjob_object)
     mock_k8s_batchv1beta1_api().create_namespaced_cron_job.assert_called_once_with(
@@ -182,26 +175,55 @@ def test_create_workflow_cronjob_tries_to_create_job_with_k8s_api(
     )
 
 
-@patch("kubernetes.client.BatchV1beta1Api")
+@patch("bodywork.k8s.workflow_jobs.k8s.BatchV1beta1Api")
+def test_updates_workflow_cronjob_updates_cronjob_with_k8s_api(
+    mock_k8s_batchv1beta1_api: MagicMock,
+):
+    pod_spec = k8s.V1PodSpec(
+        containers=[k8s.V1Container(name="bodywork", args=["fg", "test-branch"])],
+    )
+    job_spec = k8s.V1JobSpec(
+        template=k8s.V1PodTemplateSpec(spec=pod_spec),
+        backoff_limit=3,
+    )
+    job_template = k8s.V1beta1JobTemplateSpec(spec=k8s.V1Job(spec=job_spec).spec)
+    expected_result = k8s.V1beta1CronJob(
+        spec=k8s.V1beta1CronJobSpec(
+            job_template=job_template,
+            schedule="0 0 * * *",
+            successful_jobs_history_limit=1,
+            failed_jobs_history_limit=2,
+        )
+    )
+
+    update_workflow_cronjob(
+        "bodywork-ml", "test", "0 0 * * *", "fg", "test-branch", 3, 1, 2
+    )
+
+    mock_k8s_batchv1beta1_api().patch_namespaced_cron_job.assert_called_once_with(
+        "test", "bodywork-ml", expected_result
+    )
+
+
+@patch("bodywork.k8s.workflow_jobs.k8s.BatchV1beta1Api")
 def test_delete_workflow_cronjob_tries_to_delete_job_with_k8s_api(
     mock_k8s_batchv1beta1_api: MagicMock,
-    workflow_cronjob_object: kubernetes.client.V1beta1CronJob,
 ):
     delete_workflow_cronjob("bodywork-dev", "bodywork-test-project")
     mock_k8s_batchv1beta1_api().delete_namespaced_cron_job.assert_called_once_with(
         name="bodywork-test-project",
         namespace="bodywork-dev",
-        body=kubernetes.client.V1DeleteOptions(propagation_policy="Background"),
+        body=k8s.V1DeleteOptions(propagation_policy="Background"),
     )
 
 
-@patch("kubernetes.client.BatchV1beta1Api")
+@patch("bodywork.k8s.workflow_jobs.k8s.BatchV1beta1Api")
 def test_list_workflow_cronjobs_returns_cronjobs_summary_info(
     mock_k8s_batchv1beta1_api: MagicMock,
-    workflow_cronjob_object: kubernetes.client.V1beta1CronJob,
+    workflow_cronjob_object: k8s.V1beta1CronJob,
 ):
     mock_k8s_batchv1beta1_api().list_namespaced_cron_job.return_value = (
-        kubernetes.client.V1beta1CronJobList(items=[workflow_cronjob_object])
+        k8s.V1beta1CronJobList(items=[workflow_cronjob_object])
     )
     cronjobs = list_workflow_cronjobs("bodywork-dev")
     assert cronjobs["bodywork-test-project"]["schedule"] == "0,30 * * * *"
@@ -213,45 +235,43 @@ def test_list_workflow_cronjobs_returns_cronjobs_summary_info(
     )
 
 
-@patch("kubernetes.client.BatchV1Api")
+@patch("k8s.BatchV1Api")
 def test_list_workflow_jobs_returns_jobs_summary_info(
     mock_k8s_batchv1_api: MagicMock,
 ):
-    mock_k8s_batchv1_api().list_namespaced_job.return_value = (
-        kubernetes.client.V1JobList(
-            items=[
-                kubernetes.client.V1Job(
-                    metadata=kubernetes.client.V1ObjectMeta(name="workflow-job-12345"),
-                    status=kubernetes.client.V1JobStatus(
-                        start_time=datetime(2020, 10, 19, 12, 15),
-                        completion_time=None,
-                        active=1,
-                        succeeded=0,
-                        failed=0,
-                    ),
+    mock_k8s_batchv1_api().list_namespaced_job.return_value = k8s.V1JobList(
+        items=[
+            k8s.V1Job(
+                metadata=k8s.V1ObjectMeta(name="workflow-job-12345"),
+                status=k8s.V1JobStatus(
+                    start_time=datetime(2020, 10, 19, 12, 15),
+                    completion_time=None,
+                    active=1,
+                    succeeded=0,
+                    failed=0,
                 ),
-                kubernetes.client.V1Job(
-                    metadata=kubernetes.client.V1ObjectMeta(name="workflow-job-6789"),
-                    status=kubernetes.client.V1JobStatus(
-                        start_time=datetime(2020, 10, 19, 13, 15),
-                        completion_time=datetime(2020, 10, 19, 13, 30),
-                        active=0,
-                        succeeded=1,
-                        failed=0,
-                    ),
+            ),
+            k8s.V1Job(
+                metadata=k8s.V1ObjectMeta(name="workflow-job-6789"),
+                status=k8s.V1JobStatus(
+                    start_time=datetime(2020, 10, 19, 13, 15),
+                    completion_time=datetime(2020, 10, 19, 13, 30),
+                    active=0,
+                    succeeded=1,
+                    failed=0,
                 ),
-                kubernetes.client.V1Job(
-                    metadata=kubernetes.client.V1ObjectMeta(name="batch-job-12345"),
-                    status=kubernetes.client.V1JobStatus(
-                        start_time=datetime(2020, 10, 19, 12, 16),
-                        completion_time=datetime(2020, 10, 19, 12, 17),
-                        active=0,
-                        succeeded=1,
-                        failed=0,
-                    ),
+            ),
+            k8s.V1Job(
+                metadata=k8s.V1ObjectMeta(name="batch-job-12345"),
+                status=k8s.V1JobStatus(
+                    start_time=datetime(2020, 10, 19, 12, 16),
+                    completion_time=datetime(2020, 10, 19, 12, 17),
+                    active=0,
+                    succeeded=1,
+                    failed=0,
                 ),
-            ]
-        )
+            ),
+        ]
     )
     workflow_jobs = list_workflow_jobs("namespace", "workflow-job")
     assert len(workflow_jobs) == 2


### PR DESCRIPTION
This PR closes #122 . 

The update cronjob command allows a cronjob to be updated with all the currently available parameters that can specified when creating a cronjob. The only constraint imposed is that when updating either the git branch or URL, both must be specified together. 

If the cronjob schedule is not defined then the existing schedule must be retrieved because this a mandatory field when creating a cronjob. 