### PR TITLE
Change create deployment to always run locally

### DIFF
--- a/src/bodywork/cli/cli.py
+++ b/src/bodywork/cli/cli.py
@@ -121,12 +121,12 @@ def cli() -> None:
         help="Number of times to retry a failed workflow job.",
     )
     deployment_cmd_parser.add_argument(
-        "--local-workflow-controller",
-        "--local",
-        "-L",
+        "--async",
+        "--A",
+        dest="async_workflow",
         default=False,
         action="store_true",
-        help="Run the workflow-controller locally.",
+        help="Run the workflow-controller asynchronously (remotely).",
     )
     deployment_cmd_parser.add_argument(
         "--namespace",
@@ -351,7 +351,7 @@ def deployment(args: Namespace) -> None:
     retries = args.retries
     git_repo_url = args.git_repo_url
     git_repo_branch = args.git_repo_branch
-    run_workflow_controller_locally = args.local_workflow_controller
+    async_workflow = args.async_workflow
     service_name = args.service
     image = args.bodywork_docker_image
 
@@ -362,7 +362,7 @@ def deployment(args: Namespace) -> None:
         print_warn("Please specify --name for the deployment job.")
         sys.exit(1)
     if command == "create":
-        if run_workflow_controller_locally:
+        if not async_workflow:
             pass_through_args = Namespace(
                 git_repo_url=git_repo_url,
                 git_repo_branch=git_repo_branch,

--- a/src/bodywork/cli/cli.py
+++ b/src/bodywork/cli/cli.py
@@ -126,7 +126,7 @@ def cli() -> None:
         dest="async_workflow",
         default=False,
         action="store_true",
-        help="Run the workflow-controller asynchronously (remotely).",
+        help="Run the workflow-controller asynchronously (remotely on the k8s cluster).",
     )
     deployment_cmd_parser.add_argument(
         "--namespace",

--- a/tests/integration/test_k8s_with_cluster.py
+++ b/tests/integration/test_k8s_with_cluster.py
@@ -400,7 +400,8 @@ def test_deployment_of_remote_workflows(docker_image: str):
                 "create",
                 f"--name={job_name}",
                 "--git-repo-url=https://github.com/bodywork-ml/test-single-service-project.git",
-                f"--bodywork-docker-image={docker_image}"
+                f"--bodywork-docker-image={docker_image}",
+                "--async"
             ],
             encoding="utf-8",
             capture_output=True,


### PR DESCRIPTION
This PR closes #130 . 

To specify a remote/async workflow to be run, the `async` flag needs to be added to the `deployment create` command.