### PR TITLE
130 label services with git url, branch and commit hash

### DIFF
--- a/src/bodywork/k8s/deployments.py
+++ b/src/bodywork/k8s/deployments.py
@@ -134,13 +134,11 @@ def configure_service_stage_deployment(
     deployment_metadata = k8s.V1ObjectMeta(
         namespace=namespace,
         name=make_valid_k8s_name(f"{project_name}--{stage_name}"),
-        annotations={"port": port},
+        annotations={"port": str(port)},
         labels={
             "app": "bodywork",
             "stage": stage_name,
             "deployment-name": project_name,
-            "git-url": project_repo_url,
-            "git-branch": project_repo_branch,
             "git-commit-hash": git_commit_hash,
         },
     )
@@ -416,8 +414,8 @@ def list_service_stage_deployments(
                 if deployment.status.unavailable_replicas is None
                 else deployment.status.unavailable_replicas
             ),
-            "git_url": deployment.metadata.labels["git-url"],
-            "git_branch": deployment.metadata.labels["git-branch"],
+            "git_url": deployment.spec.template.spec.containers[0].args[0],
+            "git_branch": deployment.spec.template.spec.containers[0].args[1],
             "git_commit_hash": deployment.metadata.labels["git-commit-hash"],
             "has_ingress": (
                 has_ingress(deployment.metadata.namespace, deployment.metadata.name)

--- a/tests/unit_and_functional/test_cli_deployments.py
+++ b/tests/unit_and_functional/test_cli_deployments.py
@@ -43,6 +43,7 @@ def test_service_stage_deployment() -> Dict[str, Any]:
             "unavailable_replicas": 0,
             "git_url": "project_repo_url",
             "git_branch": "project_repo_branch",
+            "git_commit_hash": "abc123",
             "has_ingress": "true",
             "ingress_route": "/bodywork-dev/bodywork-test-project",
         },
@@ -55,6 +56,7 @@ def test_service_stage_deployment() -> Dict[str, Any]:
             "unavailable_replicas": 0,
             "git_url": "project_repo_url",
             "git_branch": "project_repo_branch",
+            "git_commit_hash": "abc123",
             "has_ingress": "true",
             "ingress_route": "/bodywork-dev/bodywork-test-project",
         },
@@ -149,6 +151,7 @@ def test_display_service(
     assert findall(r"unavailable_replicas.+0", captured_one.out)
     assert findall(r"git_url.+project_repo_url", captured_one.out)
     assert findall(r"git_branch.+project_repo_branch", captured_one.out)
+    assert findall(r"git_commit_hash.+abc123", captured_one.out)
     assert findall(r"service_port.+6000", captured_one.out)
     assert findall(
         r"service_url.+http://bodywork-test-project--serve-v2.bodywork-dev.svc.cluster.local",

--- a/tests/unit_and_functional/test_k8s_deployments.py
+++ b/tests/unit_and_functional/test_k8s_deployments.py
@@ -84,8 +84,6 @@ def service_stage_deployment_object() -> kubernetes.client.V1Deployment:
         labels={
             "app": "bodywork",
             "deployment-name": "myproject",
-            "git-url": "project_repo_url",
-            "git-branch": "project_repo_branch",
             "git-commit-hash": "abc123",
         }
     )

--- a/tests/unit_and_functional/test_k8s_deployments.py
+++ b/tests/unit_and_functional/test_k8s_deployments.py
@@ -81,6 +81,13 @@ def service_stage_deployment_object() -> kubernetes.client.V1Deployment:
         namespace="bodywork-dev",
         name="bodywork-test-project--serve",
         annotations={"port": "5000"},
+        labels={
+            "app": "bodywork",
+            "deployment-name": "myproject",
+            "git-url": "project_repo_url",
+            "git-branch": "project_repo_branch",
+            "git-commit-hash": "abc123",
+        }
     )
     deployment = kubernetes.client.V1Deployment(
         metadata=deployment_metadata, spec=deployment_spec
@@ -94,6 +101,7 @@ def test_configure_service_stage_deployment():
         stage_name="serve",
         project_name="bodywork-test-project",
         project_repo_url="bodywork-ml/bodywork-test-project",
+        git_commit_hash="xyz123",
         project_repo_branch="dev",
         image="bodyworkml/bodywork-core:latest",
         replicas=2,
@@ -485,6 +493,7 @@ def test_list_service_stage_deployments_returns_service_stage_info(
                     deployment_info[service_name]["git_branch"] == "project_repo_branch"
                 )  # noqa
                 assert deployment_info[service_name]["git_url"] == "project_repo_url"
+                assert deployment_info[service_name]["git_commit_hash"] == "abc123"
                 assert deployment_info[service_name]["has_ingress"] is True
 
 

--- a/tests/unit_and_functional/test_workflow_execution.py
+++ b/tests/unit_and_functional/test_workflow_execution.py
@@ -165,6 +165,7 @@ def test_run_workflow_adds_git_commit_to_batch_and_service_env_vars(
         ANY,
         ANY,
         ANY,
+        ANY,
         replicas=ANY,
         port=ANY,
         container_env_vars=expected_result,


### PR DESCRIPTION
This PR closes #130 . 

This task was changed to just adding the git-commit hash as a label because there are restrictions on the size and content of label names that prevent the git-url from being used as one.