### PR TITLE
131 modify workflow runner to delete all redundant services

### DIFF
--- a/src/bodywork/workflow_execution.py
+++ b/src/bodywork/workflow_execution.py
@@ -144,13 +144,15 @@ def run_workflow(
                         repo_branch,
                         repo_url,
                         docker_image,
-                        git_commit_hash
+                        git_commit_hash,
                     )
                 _log.info(f"Successfully executed DAG step = [{', '.join(step)}]")
             _log.info("Deployment successful")
             if not workflow_deploys_services(config):
                 _log.info(f"Deleting namespace = {namespace}")
                 k8s.delete_namespace(namespace)
+            else:
+                _cleanup_redundant_services(git_commit_hash, namespace)
             if config.project.usage_stats:
                 _ping_usage_stats_server()
         except Exception as e:
@@ -185,6 +187,18 @@ def run_workflow(
             if cloned_repo_dir.exists():
                 rmtree(cloned_repo_dir, onerror=_remove_readonly)
     console.rule(characters="=", style="green")
+
+
+def _cleanup_redundant_services(git_commit_hash, namespace) -> None:
+    _log.info("Searching for services from previous deployment.")
+    deployments = k8s.list_service_stage_deployments(namespace)
+    for name, deployment in deployments.items():
+        if deployment["git_commit_hash"] != git_commit_hash:
+            _log.info(
+                f"Removing service: {name} from previous deployment with "
+                f"git-commit-hash: {deployment['git_commit_hash']}."
+            )
+            k8s.delete_deployment(namespace, name)
 
 
 def _setup_namespace(config) -> str:

--- a/tests/integration/test_k8s_with_cluster.py
+++ b/tests/integration/test_k8s_with_cluster.py
@@ -147,6 +147,71 @@ def test_workflow_and_service_management_end_to_end_from_cli(
             delete_cluster_role_binding(workflow_sa_crb)
 
 
+def test_deployment_of_remote_workflows(docker_image: str):
+    job_name = "test-remote-workflows"
+    try:
+        process_one = run(
+            [
+                "bodywork",
+                "deployment",
+                "create",
+                f"--name={job_name}",
+                "--git-repo-url=https://github.com/bodywork-ml/test-single-service-project.git",
+                f"--bodywork-docker-image={docker_image}",
+                "--async",
+            ],
+            encoding="utf-8",
+            capture_output=True,
+        )
+        assert process_one.returncode == 0
+        assert f"Created workflow-job={job_name}" in process_one.stdout
+
+        sleep(20)
+
+        process_two = run(
+            [
+                "bodywork",
+                "deployment",
+                "display",
+                "--name=bodywork-test-single-service-project",
+            ],
+            encoding="utf-8",
+            capture_output=True,
+        )
+        assert process_two.returncode == 0
+        assert "bodywork-test-single-service-project" in process_two.stdout
+
+        process_three = run(
+            [
+                "bodywork",
+                "deployment",
+                "logs",
+                f"--name={job_name}",
+            ],
+            encoding="utf-8",
+            capture_output=True,
+        )
+        assert process_three.returncode == 0
+        assert type(process_three.stdout) is str and len(process_three.stdout) != 0
+        assert "ERROR" not in process_three.stdout
+
+    except Exception:
+        assert False
+    finally:
+        load_kubernetes_config()
+        run(
+            [
+                "kubectl",
+                "delete",
+                "job",
+                f"{job_name}",
+                f"--namespace={BODYWORK_DEPLOYMENT_JOBS_NAMESPACE}",
+            ]
+        )
+        delete_namespace("bodywork-test-single-service-project")
+        rmtree(SSH_DIR_NAME, ignore_errors=True)
+        
+
 def test_workflow_will_cleanup_jobs_and_rollback_new_deployments_that_yield_errors(
     docker_image: str,
 ):
@@ -257,71 +322,6 @@ def test_workflow_will_not_run_if_bodywork_docker_image_cannot_be_located():
         assert process_two.returncode == 1
     finally:
         delete_namespace("bodywork-test-project")
-
-
-def test_deployment_of_remote_workflows(docker_image: str):
-    job_name = "test-remote-workflows"
-    try:
-        process_one = run(
-            [
-                "bodywork",
-                "deployment",
-                "create",
-                f"--name={job_name}",
-                "--git-repo-url=https://github.com/bodywork-ml/test-single-service-project.git",
-                f"--bodywork-docker-image={docker_image}",
-                "--async",
-            ],
-            encoding="utf-8",
-            capture_output=True,
-        )
-        assert process_one.returncode == 0
-        assert f"Created workflow-job={job_name}" in process_one.stdout
-
-        sleep(20)
-
-        process_two = run(
-            [
-                "bodywork",
-                "deployment",
-                "display",
-                "--name=bodywork-test-single-service-project",
-            ],
-            encoding="utf-8",
-            capture_output=True,
-        )
-        assert process_two.returncode == 0
-        assert "bodywork-test-single-service-project" in process_two.stdout
-
-        process_three = run(
-            [
-                "bodywork",
-                "deployment",
-                "logs",
-                f"--name={job_name}",
-            ],
-            encoding="utf-8",
-            capture_output=True,
-        )
-        assert process_three.returncode == 0
-        assert type(process_three.stdout) is str and len(process_three.stdout) != 0
-        assert "ERROR" not in process_three.stdout
-
-    except Exception:
-        assert False
-    finally:
-        load_kubernetes_config()
-        run(
-            [
-                "kubectl",
-                "delete",
-                "job",
-                f"{job_name}",
-                f"--namespace={BODYWORK_DEPLOYMENT_JOBS_NAMESPACE}",
-            ]
-        )
-        delete_namespace("bodywork-test-single-service-project")
-        rmtree(SSH_DIR_NAME, ignore_errors=True)
 
 
 def test_workflow_with_ssh_github_connectivity(

--- a/tests/integration/test_k8s_with_cluster.py
+++ b/tests/integration/test_k8s_with_cluster.py
@@ -468,7 +468,7 @@ def test_services_from_previous_deployments_are_deleted():
         assert process_one.returncode == 0
         assert "Deployment successful" in process_one.stdout
 
-        sleep(5)
+        sleep(15)
 
         process_two = run(
             [

--- a/tests/integration/test_k8s_with_cluster.py
+++ b/tests/integration/test_k8s_with_cluster.py
@@ -26,10 +26,7 @@ from time import sleep
 
 from pytest import raises, mark
 
-from bodywork.constants import (
-    SSH_DIR_NAME,
-    BODYWORK_DEPLOYMENT_JOBS_NAMESPACE
-)
+from bodywork.constants import SSH_DIR_NAME, BODYWORK_DEPLOYMENT_JOBS_NAMESPACE
 from bodywork.k8s import (
     cluster_role_binding_exists,
     delete_cluster_role_binding,
@@ -151,7 +148,7 @@ def test_workflow_and_service_management_end_to_end_from_cli(
 
 
 def test_workflow_will_cleanup_jobs_and_rollback_new_deployments_that_yield_errors(
-    docker_image: str
+    docker_image: str,
 ):
     try:
         process_one = run(
@@ -239,10 +236,7 @@ def test_workflow_will_not_run_if_bodywork_docker_image_cannot_be_located():
             encoding="utf-8",
             capture_output=True,
         )
-        assert (
-            f"Invalid Docker image specified: {bad_image}"
-            in process_one.stdout
-        )
+        assert f"Invalid Docker image specified: {bad_image}" in process_one.stdout
         assert process_one.returncode == 1
 
         process_two = run(
@@ -281,9 +275,7 @@ def test_workflow_with_ssh_github_connectivity(
             encoding="utf-8",
             capture_output=True,
         )
-        expected_output_1 = (
-            "deploying master branch from git@github.com:bodywork-ml/test-bodywork-batch-job-project.git"   # noqa
-        )
+        expected_output_1 = "deploying master branch from git@github.com:bodywork-ml/test-bodywork-batch-job-project.git"  # noqa
         expected_output_2 = "Deployment successful"
 
         assert expected_output_1 in process_one.stdout
@@ -354,7 +346,10 @@ def test_cli_cronjob_handler_crud():
         )
         assert "bodywork-test-project" in process_three.stdout
         assert "0,0 1 * * *" in process_three.stdout
-        assert ("https://github.com/bodywork-ml/bodywork-test-project" in process_three.stdout)  # noqa
+        assert (
+            "https://github.com/bodywork-ml/bodywork-test-project"
+            in process_three.stdout
+        )  # noqa
         assert "main" in process_three.stdout
         assert process_three.returncode == 0
 
@@ -401,7 +396,7 @@ def test_deployment_of_remote_workflows(docker_image: str):
                 f"--name={job_name}",
                 "--git-repo-url=https://github.com/bodywork-ml/test-single-service-project.git",
                 f"--bodywork-docker-image={docker_image}",
-                "--async"
+                "--async",
             ],
             encoding="utf-8",
             capture_output=True,
@@ -453,3 +448,60 @@ def test_deployment_of_remote_workflows(docker_image: str):
         )
         delete_namespace("bodywork-test-single-service-project")
         rmtree(SSH_DIR_NAME, ignore_errors=True)
+
+
+def test_services_from_previous_deployments_are_deleted():
+    job_name = "test-service-cleanup"
+    try:
+        process_one = run(
+            [
+                "bodywork",
+                "deployment",
+                "create",
+                f"--name={job_name}",
+                "--git-repo-url=https://github.com/bodywork-ml/test-single-service-project.git",
+                "--git-repo-branch=test-two-services",
+            ],
+            encoding="utf-8",
+            capture_output=True,
+        )
+        assert process_one.returncode == 0
+        assert "Deployment successful" in process_one.stdout
+
+        process_two = run(
+            [
+                "bodywork",
+                "deployment",
+                "create",
+                f"--name={job_name}",
+                "--git-repo-url=https://github.com/bodywork-ml/test-single-service-project.git",
+            ],
+            encoding="utf-8",
+            capture_output=True,
+        )
+        assert process_two.returncode == 0
+        assert "Deployment successful" in process_two.stdout
+        assert (
+            "Removing service: bodywork-test-single-service-project--stage-2 from previous deployment with git-commit-hash" # noqa
+            in process_two.stdout
+        )
+
+        process_three = run(
+            [
+                "bodywork",
+                "deployment",
+                "display",
+                "--name=bodywork-test-single-service-project",
+            ],
+            encoding="utf-8",
+            capture_output=True,
+        )
+        assert process_three.returncode == 0
+        assert "bodywork-test-single-service-project--stage-1" in process_three.stdout
+        assert (
+            "bodywork-test-single-service-project--stage-2" not in process_three.stdout
+        )
+
+    finally:
+        load_kubernetes_config()
+        delete_namespace("bodywork-test-single-service-project")

--- a/tests/integration/test_k8s_with_cluster.py
+++ b/tests/integration/test_k8s_with_cluster.py
@@ -210,7 +210,7 @@ def test_deployment_of_remote_workflows(docker_image: str):
         )
         delete_namespace("bodywork-test-single-service-project")
         rmtree(SSH_DIR_NAME, ignore_errors=True)
-        
+
 
 def test_workflow_will_cleanup_jobs_and_rollback_new_deployments_that_yield_errors(
     docker_image: str,
@@ -467,6 +467,8 @@ def test_services_from_previous_deployments_are_deleted():
         )
         assert process_one.returncode == 0
         assert "Deployment successful" in process_one.stdout
+
+        sleep(5)
 
         process_two = run(
             [

--- a/tests/unit_and_functional/conftest.py
+++ b/tests/unit_and_functional/conftest.py
@@ -19,7 +19,7 @@ Pytest fixtures for use with all unit and functional testing modules.
 """
 import os
 
-from typing import Iterable
+from typing import Iterable, Dict, Any
 from pytest import fixture
 
 
@@ -32,3 +32,35 @@ def k8s_env_vars() -> Iterable[bool]:
     finally:
         yield True
     del os.environ["KUBERNETES_SERVICE_HOST"]
+
+
+@fixture(scope="function")
+def test_service_stage_deployment() -> Dict[str, Any]:
+    return {
+        "bodywork-test-project--serve-v1": {
+            "namespace": "bodywork-dev",
+            "service_url": "http://bodywork-test-project--serve.bodywork-dev.svc.cluster.local",  # noqa
+            "service_port": 5000,
+            "service_exposed": "true",
+            "available_replicas": 1,
+            "unavailable_replicas": 0,
+            "git_url": "project_repo_url",
+            "git_branch": "project_repo_branch",
+            "git_commit_hash": "abc123",
+            "has_ingress": "true",
+            "ingress_route": "/bodywork-dev/bodywork-test-project",
+        },
+        "bodywork-test-project--serve-v2": {
+            "namespace": "bodywork-dev",
+            "service_url": "http://bodywork-test-project--serve-v2.bodywork-dev.svc.cluster.local",  # noqa
+            "service_port": 6000,
+            "service_exposed": "true",
+            "available_replicas": 1,
+            "unavailable_replicas": 0,
+            "git_url": "project_repo_url",
+            "git_branch": "project_repo_branch",
+            "git_commit_hash": "xyz123",
+            "has_ingress": "true",
+            "ingress_route": "/bodywork-dev/bodywork-test-project",
+        },
+    }

--- a/tests/unit_and_functional/test_cli_deployments.py
+++ b/tests/unit_and_functional/test_cli_deployments.py
@@ -21,7 +21,6 @@ from re import findall
 from unittest.mock import MagicMock, patch
 
 from _pytest.capture import CaptureFixture
-from pytest import fixture
 from typing import Dict, Any
 
 from bodywork.cli.deployments import (
@@ -29,38 +28,6 @@ from bodywork.cli.deployments import (
     display_deployments,
     delete_deployment,
 )
-
-
-@fixture(scope="function")
-def test_service_stage_deployment() -> Dict[str, Any]:
-    return {
-        "bodywork-test-project--serve-v1": {
-            "namespace": "bodywork-dev",
-            "service_url": "http://bodywork-test-project--serve.bodywork-dev.svc.cluster.local",  # noqa
-            "service_port": 5000,
-            "service_exposed": "true",
-            "available_replicas": 1,
-            "unavailable_replicas": 0,
-            "git_url": "project_repo_url",
-            "git_branch": "project_repo_branch",
-            "git_commit_hash": "abc123",
-            "has_ingress": "true",
-            "ingress_route": "/bodywork-dev/bodywork-test-project",
-        },
-        "bodywork-test-project--serve-v2": {
-            "namespace": "bodywork-dev",
-            "service_url": "http://bodywork-test-project--serve-v2.bodywork-dev.svc.cluster.local",  # noqa
-            "service_port": 6000,
-            "service_exposed": "true",
-            "available_replicas": 1,
-            "unavailable_replicas": 0,
-            "git_url": "project_repo_url",
-            "git_branch": "project_repo_branch",
-            "git_commit_hash": "abc123",
-            "has_ingress": "true",
-            "ingress_route": "/bodywork-dev/bodywork-test-project",
-        },
-    }
 
 
 @patch("bodywork.cli.deployments.k8s")

--- a/tests/unit_and_functional/test_cli_deployments.py
+++ b/tests/unit_and_functional/test_cli_deployments.py
@@ -118,7 +118,7 @@ def test_display_service(
     assert findall(r"unavailable_replicas.+0", captured_one.out)
     assert findall(r"git_url.+project_repo_url", captured_one.out)
     assert findall(r"git_branch.+project_repo_branch", captured_one.out)
-    assert findall(r"git_commit_hash.+abc123", captured_one.out)
+    assert findall(r"git_commit_hash.+xyz123", captured_one.out)
     assert findall(r"service_port.+6000", captured_one.out)
     assert findall(
         r"service_url.+http://bodywork-test-project--serve-v2.bodywork-dev.svc.cluster.local",

--- a/tests/unit_and_functional/test_workflow_execution.py
+++ b/tests/unit_and_functional/test_workflow_execution.py
@@ -17,10 +17,9 @@
 """
 Test Bodywork workflow execution.
 """
-import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch, ANY
-from typing import Iterable
+from typing import Iterable, Dict, Any
 
 import requests
 from pytest import raises
@@ -412,3 +411,28 @@ def test_namespace_is_deleted_if_only_batch_stages(
         pass
 
     mock_k8s.delete_namespace.assert_called()
+
+
+@patch("bodywork.workflow_execution.rmtree")
+@patch("bodywork.workflow_execution.requests.Session")
+@patch("bodywork.workflow_execution.download_project_code_from_repo")
+@patch("bodywork.workflow_execution.get_git_commit_hash")
+@patch("bodywork.workflow_execution.k8s")
+def test_old_deployments_are_cleaned_up(
+    mock_k8s: MagicMock,
+    mock_git_hash: MagicMock,
+    mock_git_download: MagicMock,
+    mock_session: MagicMock,
+    mock_rmtree: MagicMock,
+    project_repo_location: Path,
+    test_service_stage_deployment: Dict[str, Any]
+):
+    config_path = Path(f"{project_repo_location}/bodywork.yaml")
+    config = BodyworkConfig(config_path)
+
+    mock_git_hash.return_value = test_service_stage_deployment["bodywork-test-project--serve-v2"]["git_commit_hash"]
+    mock_k8s.list_service_stage_deployments.return_value = test_service_stage_deployment
+
+    run_workflow("foo_bar_foo_993", project_repo_location, config=config)
+
+    mock_k8s.delete_deployment.assert_called_once_with("bodywork-test-project", "bodywork-test-project--serve-v1")


### PR DESCRIPTION
This PR closes #131 . 

Redundant services are cleaned up according to the git-commit hash i.e. If the service belong to a different git-commit hash then it is deleted.