### PR TITLE
132 modify workflow runner to avoid potentially conflicting deployments

### DIFF
--- a/src/bodywork/cli/deployments.py
+++ b/src/bodywork/cli/deployments.py
@@ -77,13 +77,14 @@ def delete_service_deployment_in_namespace(namespace: str, name: str) -> None:
         )
 
 
-def delete_deployment(deployment_name) -> None:
+def delete_deployment(deployment_name: str) -> None:
     """Delete a deployment by deleting the namespace it's in.
 
     :param deployment_name: The name of the deployment.
     """
-    if not k8s.namespace_exists(deployment_name):
+    deployments = k8s.list_service_stage_deployments(name=deployment_name)
+    if not deployments:
         print_info(f"deployment={deployment_name} could not be found on k8s cluster.")
         return None
-    k8s.delete_namespace(deployment_name)
+    k8s.delete_namespace(list(deployments.values())[0]["namespace"])
     print_info(f"deployment={deployment_name} deleted.")

--- a/src/bodywork/workflow_execution.py
+++ b/src/bodywork/workflow_execution.py
@@ -210,6 +210,7 @@ def _setup_namespace(config: BodyworkConfig, repo_url: str) -> str:
     """Creates namespace to run workflow in.
 
     :param config: Bodywork config.
+    :param config: Git repository URL.
     :return: Name of namespace.
     """
     namespace = str(

--- a/src/bodywork/workflow_execution.py
+++ b/src/bodywork/workflow_execution.py
@@ -226,8 +226,10 @@ def _setup_namespace(config: BodyworkConfig, repo_url: str) -> str:
             for name, deployment in deployments.items():
                 if deployment["git_url"] != repo_url:
                     raise BodyworkNamespaceError(
-                        f"A project with the same name (or namespace): {namespace}, originating from a different git"   # noqa
-                        f" repository, has already been deployed. Please choose another name.")  # noqa
+                        f"A project with the same name (or namespace): {namespace},"
+                        " originating from a different git repository, has already "
+                        "been deployed. Please choose another name."
+                    )
         if not k8s.service_account_exists(namespace, BODYWORK_STAGES_SERVICE_ACCOUNT):
             _log.info(
                 f"Creating k8s service account = {BODYWORK_STAGES_SERVICE_ACCOUNT}"

--- a/tests/integration/test_k8s_with_cluster.py
+++ b/tests/integration/test_k8s_with_cluster.py
@@ -154,8 +154,8 @@ def test_services_from_previous_deployments_are_deleted():
                 "bodywork",
                 "deployment",
                 "create",
-                "--git-repo-url=https://github.com/bodywork-ml/test-single-service-project.git",
-                "--git-repo-branch=test-two-services",
+                "--git-url=https://github.com/bodywork-ml/test-single-service-project.git",
+                "--git-branch=test-two-services",
             ],
             encoding="utf-8",
             capture_output=True,
@@ -170,8 +170,8 @@ def test_services_from_previous_deployments_are_deleted():
                 "bodywork",
                 "deployment",
                 "create",
-                "--git-repo-url=https://github.com/bodywork-ml/test-single-service-project.git",
-                "--git-repo-branch=master"
+                "--git-url=https://github.com/bodywork-ml/test-single-service-project.git",
+                "--git-branch=master"
             ],
             encoding="utf-8",
             capture_output=True,

--- a/tests/unit_and_functional/conftest.py
+++ b/tests/unit_and_functional/conftest.py
@@ -38,7 +38,7 @@ def k8s_env_vars() -> Iterable[bool]:
 def test_service_stage_deployment() -> Dict[str, Any]:
     return {
         "bodywork-test-project--serve-v1": {
-            "namespace": "bodywork-dev",
+            "namespace": "bodywork-test-project",
             "service_url": "http://bodywork-test-project--serve.bodywork-dev.svc.cluster.local",  # noqa
             "service_port": 5000,
             "service_exposed": "true",
@@ -51,7 +51,7 @@ def test_service_stage_deployment() -> Dict[str, Any]:
             "ingress_route": "/bodywork-dev/bodywork-test-project",
         },
         "bodywork-test-project--serve-v2": {
-            "namespace": "bodywork-dev",
+            "namespace": "bodywork-test-project",
             "service_url": "http://bodywork-test-project--serve-v2.bodywork-dev.svc.cluster.local",  # noqa
             "service_port": 6000,
             "service_exposed": "true",

--- a/tests/unit_and_functional/test_cli_deployments.py
+++ b/tests/unit_and_functional/test_cli_deployments.py
@@ -223,10 +223,13 @@ def test_delete_deployment_in_namespace(
 
 
 @patch("bodywork.cli.deployments.k8s")
-def test_delete_deployment(mock_k8s_module: MagicMock, capsys: CaptureFixture):
-    mock_k8s_module.namespace_exists.return_value = False
-    mock_k8s_module.list_service_stage_deployments.return_value = {"foo": {}}
-    deployment_name = "bodywork-test-project--serve"
+def test_delete_deployment(
+    mock_k8s_module: MagicMock,
+    capsys: CaptureFixture,
+    test_service_stage_deployment: Dict[str, Any],
+):
+    deployment_name = "bodywork-test-project"
+    mock_k8s_module.list_service_stage_deployments.return_value = []
 
     delete_deployment(deployment_name)
 
@@ -236,8 +239,10 @@ def test_delete_deployment(mock_k8s_module: MagicMock, capsys: CaptureFixture):
         in captured_one.out
     )
 
-    mock_k8s_module.namespace_exists.return_value = True
+    mock_k8s_module.list_service_stage_deployments.return_value = (
+        test_service_stage_deployment
+    )
 
-    delete_deployment("bodywork-test-project--serve")
+    delete_deployment(deployment_name)
 
     mock_k8s_module.delete_namespace.assert_called_with(deployment_name)

--- a/tests/unit_and_functional/test_workflow_execution.py
+++ b/tests/unit_and_functional/test_workflow_execution.py
@@ -463,6 +463,6 @@ def test_cannot_deploy_different_project_repo_to_same_namespace(
 
     with raises(
         BodyworkWorkflowExecutionError,
-        match=r"A project with the name \(or namespace\): bodywork-test-project",
+        match=r"A project with the same name \(or namespace\): bodywork-test-project",
     ):
         run_workflow("https://my_new_project", config=config)


### PR DESCRIPTION
This PR closes #132 . 

To avoid conflicting deployments:

1. If a project is deployed to a namespace that already exists then a check is carried out to see if there are any other deployments in this namespace. 
2. If there are, compare the git urls to the project being deployed to see if they belong to the same project. 
3. If they do not, then do not deploy and return a message to the user. 

